### PR TITLE
Added satellite (Bing) and other layers (default is now OSM HOT)

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ require.config({
     "leaflet": "../bower_components/leaflet/dist/leaflet",
     "leaflet.label": "../bower_components/Leaflet.label/dist/leaflet.label",
     "leaflet.providers": "../bower_components/leaflet-providers/leaflet-providers",
+    "leaflet-plugins.bing": "../bower_components/leaflet-plugins/layer/tile/Bing",
     "chroma-js": "../bower_components/chroma-js/chroma.min",
     "moment": "../bower_components/moment/min/moment-with-locales.min",
     "tablesort": "../bower_components/tablesort/tablesort.min",
@@ -19,6 +20,7 @@ require.config({
   shim: {
     "leaflet.label": ["leaflet"],
     "leaflet.providers": ["leaflet"],
+    "leaflet-plugins.bing": ["leaflet"],
     "tablesort": {
       exports: "Tablesort"
     },

--- a/config.js.example
+++ b/config.js.example
@@ -5,17 +5,48 @@ define({
   "showContact": true,
   "maxAge": 14,
   "mapLayers": [
-    { "name": "MapQuest",
-      "url": "https://otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
+    {
+      "name": "Karte (Humanitarian)",
+      "provider": "OpenStreetMap.HOT",
       "config": {
-        "subdomains": "1234",
-        "type": "osm",
-        "attribution": "Tiles &copy; <a href=\"https://www.mapquest.com/\" target=\"_blank\">MapQuest</a>, Data CC-BY-SA OpenStreetMap",
-        "maxZoom": 18
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. Tiles courtesy of <a href=\"http://hot.openstreetmap.org\" target=\"_blank\">Humanitarian OpenStreetMap Team</a>",
+        "maxZoom": 20
       }
     },
     {
-      "name": "Stamen.TonerLite"
+      "name": "Karte (OSM Mapnik)",
+      "provider": "OpenStreetMap",
+      "config": {
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. ♥ <a href=\"http://donate.openstreetmap.org\" class=\"donate-attr\">Make a Donation</a>",
+      }
+    },
+    {
+      "name": "Karte (MapQuest Open)",
+      "provider": "MapQuestOpen",
+      "config": {
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. Tiles courtesy of <a href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"https://developer.mapquest.com/content/osm/mq_logo.png\">",
+        "maxZoom": 19
+      }
+    },
+    {
+      "name": "Satelit (Bing)",
+      "provider": "Bing",
+      "config": {
+        "key": "<Your key>",
+        "type": "AerialWithLabels",
+        "maxZoom": 20
+      }
+    },
+    {
+      "name": "Einfarbige Karte (CartoDB)",
+      "provider": "CartoDB",
+      "config": {
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>"
+      }
+    },
+    {
+      "name": "Einfarbige Karte (Stamen Toner Lines)",
+      "provider": "Stamen.TonerLite"
     }
   ]
 })

--- a/config.js.ffmuc
+++ b/config.js.ffmuc
@@ -27,13 +27,43 @@ define({
     },
    ],
   "mapLayers": [
-    { "name": "MapQuest",
-      "url": "https://otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
+    {
+      "name": "Karte (Humanitarian)",
+      "provider": "OpenStreetMap.HOT",
       "config": {
-        "subdomains": "1234",
-        "type": "osm",
-        "attribution": "Tiles &copy; <a href=\"https://www.mapquest.com/\" target=\"_blank\">MapQuest</a>, Data CC-BY-SA OpenStreetMap",
-        "maxZoom": 18
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. Tiles courtesy of <a href=\"http://hot.openstreetmap.org\" target=\"_blank\">Humanitarian OpenStreetMap Team</a>",
+        "maxZoom": 20
+      }
+    },
+    {
+      "name": "Karte (OSM Mapnik)",
+      "provider": "OpenStreetMap",
+      "config": {
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. ♥ <a href=\"http://donate.openstreetmap.org\" class=\"donate-attr\">Make a Donation</a>"
+      }
+    },
+    {
+      "name": "Karte (MapQuest Open)",
+      "provider": "MapQuestOpen",
+      "config": {
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. Tiles courtesy of <a href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"https://developer.mapquest.com/content/osm/mq_logo.png\">",
+        "maxZoom": 19
+      }
+    },
+    {
+      "name": "Satelit (Bing)",
+      "provider": "Bing",
+      "config": {
+        "key": "Aiex7HstTT61uOhqmHRbtxFsOO8nd1LLpf_C1n30HPbzX0hvTO4TAAAWJWDZ0J5N",
+        "type": "AerialWithLabels",
+        "maxZoom": 20
+      }
+    },
+    {
+      "name": "Einfarbige Karte (CartoDB)",
+      "provider": "CartoDB",
+      "config": {
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>. &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>"
       }
     }
   ]

--- a/lib/map.js
+++ b/lib/map.js
@@ -1,6 +1,6 @@
 define(["map/clientlayer", "map/labelslayer",
         "d3", "leaflet", "moment", "locationmarker", "rbush",
-        "leaflet.label", "leaflet.providers"],
+        "leaflet.label", "leaflet.providers", "leaflet-plugins.bing"],
   function (ClientLayer, LabelsLayer, d3, L, moment, LocationMarker, rbush) {
     var options = { worldCopyJump: true,
                     zoomControl: false
@@ -216,10 +216,20 @@ define(["map/clientlayer", "map/labelslayer",
       map = L.map(el, options)
 
       var layers = config.mapLayers.map( function (d) {
-        return {
-          "name": d.name,
-          "layer": "url" in d ? L.tileLayer(d.url, d.config) : L.tileLayer.provider(d.name)
+        var layer = {
+          "name": d.name
         }
+
+        if("provider" in d)
+          if(d.provider === "Bing")
+            layer.layer = L.bingLayer(d.config.key, d.config)
+          else
+            layer.layer = L.tileLayer.provider(d.provider, d.config)
+        else if("url" in d)
+          layer.layer = L.tileLayer(d.url, d.config)
+        else // This should deprecated
+          layer.layer = L.tileLayer.provider(d.name, d.config)
+        return layer
       })
 
       layers[0].layer.addTo(map)


### PR DESCRIPTION
* Added a satellite layer (and an Bing Maps key)
* Replaced the default, jpeg artifact distorted, MapQuest layer with the mid-contrast, mid-annotated OSM HOT layer (MapQuest sill remains and has even got one extra zoom level :) )
* Added an nearly gray scale layer (for focusing on the nodes) and the default OSM layer (for a lot of details)
* All layers have a zoom level between 19 and 20, which is higher than the previous max zoom 18 (default layer has a max zoom 20)
* The attribution of the layers is the same as on https://osm.org
* The technical definition of the layers depends now on the leaflet-providers bower package (automatic updates, less maintenance work)