### PR TITLE
Split coords in lat and long

### DIFF
--- a/config.js.ffmuc
+++ b/config.js.ffmuc
@@ -1,6 +1,7 @@
 define({
   "dataPath": "https://ffmuc.net/data/",
   "siteName": "Freifunk München",
+  "siteURL": "https://ffmuc.net/map/",
   "mapSigmaScale": 0.5,
   "showContact": true,
   "maxAge": 14,

--- a/lib/infobox/location.js
+++ b/lib/infobox/location.js
@@ -39,14 +39,14 @@ define(function () {
         switch2plain()
         return false
     }
-    a1.href = "https://ffmuc.net/map/"
+    a1.href = config.siteURL
     var a2 = document.createElement("a")
     a2.textContent = "uci"
     a2.onclick = function() {
         switch2uci()
         return false
     }
-    a2.href = "https://ffmuc.net/map/"
+    a2.href = config.siteURL
 
     var p3 = document.createElement("p")
     p3.textContent = "Du kannst zwischen "

--- a/lib/infobox/location.js
+++ b/lib/infobox/location.js
@@ -9,18 +9,86 @@ define(function () {
       h2.textContent = result.display_name
     })
 
-    var textbox = document.createElement("textarea")
-    var gpsString = d.lat.toFixed(5)  +  "," + d.lng.toFixed(5)
-    textbox.value = gpsString
-
-    var div = document.createElement("div")
-    div.innerHTML = "<p>Drücke Strg-C um die Koordinaten zu kopieren.</p>"
+    var h3lat = document.createElement("h3")
+    h3lat.textContent = "Längengrad"
+    el.appendChild(h3lat)
+    var txt1 = document.createElement("textarea")
+    txt1.className = "lat-box"
+    txt1.id = "area1"
+    txt1.value = d.lat.toFixed(5)
     var p = document.createElement("p")
-    div.appendChild(p)
-    p.appendChild(textbox)
-    el.appendChild(div)
+    p.appendChild(txt1)
+    p.appendChild(createCopyButton(txt1.className))
+    el.appendChild(p)
 
-    textbox.select()
-    textbox.focus()
+    var h3lng = document.createElement("h3")
+    h3lng.textContent = "Breitengrad"
+    el.appendChild(h3lng)
+    var txt2 = document.createElement("textarea")
+    txt2.className = "lng-box"
+    txt2.id = "area2"
+    txt2.value = d.lng.toFixed(5)
+    var p2 = document.createElement("p")
+    p2.appendChild(txt2)
+    p2.appendChild(createCopyButton(txt2.className))
+    el.appendChild(p2)
+
+    var a1 = document.createElement("a")
+    a1.textContent = "plain"
+    a1.onclick = function() {
+        switch2plain()
+        return false
+    }
+    a1.href = "https://ffmuc.net/map/"
+    var a2 = document.createElement("a")
+    a2.textContent = "uci"
+    a2.onclick = function() {
+        switch2uci()
+        return false
+    }
+    a2.href = "https://ffmuc.net/map/"
+
+    var p3 = document.createElement("p")
+    p3.textContent = "Du kannst zwischen "
+    p3.appendChild(a1)
+    var t1 = document.createTextNode(" und ")
+    p3.appendChild(t1)
+    p3.appendChild(a2)
+    var t2 = document.createTextNode(" wechseln.")
+    p3.appendChild(t2)
+    el.appendChild(p3)
+
+    function createCopyButton(name) {
+        var btn = document.createElement("button")
+        btn.className = "copy"
+        btn.title = "Kopiere"
+        btn.onclick = function() {
+            copy2clip(name)
+        }
+        return btn
+    }
+    function copy2clip(name) {
+        var copyTextarea = document.querySelector("." + name)
+        copyTextarea.select()
+        try {
+            var successful = document.execCommand("copy")
+            var msg = successful ? "successful" : "unsuccessful"
+            console.log("Copying text command was " + msg)
+        } catch (err) {
+            console.log("Oops, unable to copy")
+        }
+    }
+    function switch2plain() {
+		var box1 = document.getElementById("area1")
+		box1.value = d.lat.toFixed(5)
+		var box2 = document.getElementById("area2")
+		box2.value = d.lng.toFixed(5)
+    }
+    function switch2uci() {
+        var box1 = document.getElementById("area1")
+		box1.value = "uci set gluon-node-info.@location[0].latitude='" + d.lat.toFixed(5) + "'"
+		var box2 = document.getElementById("area2")
+		box2.value = "uci set gluon-node-info.@location[0].longitude='" + d.lng.toFixed(5) + "'"
+    }
   }
 })

--- a/lib/infobox/location.js
+++ b/lib/infobox/location.js
@@ -13,24 +13,22 @@ define(function () {
     h3lat.textContent = "Längengrad"
     el.appendChild(h3lat)
     var txt1 = document.createElement("textarea")
-    txt1.className = "lat-box"
-    txt1.id = "area1"
+    txt1.id = "location-latitude"
     txt1.value = d.lat.toFixed(5)
     var p = document.createElement("p")
     p.appendChild(txt1)
-    p.appendChild(createCopyButton(txt1.className))
+    p.appendChild(createCopyButton(txt1.id))
     el.appendChild(p)
 
     var h3lng = document.createElement("h3")
     h3lng.textContent = "Breitengrad"
     el.appendChild(h3lng)
     var txt2 = document.createElement("textarea")
-    txt2.className = "lng-box"
-    txt2.id = "area2"
+    txt2.id = "location-longitude"
     txt2.value = d.lng.toFixed(5)
     var p2 = document.createElement("p")
     p2.appendChild(txt2)
-    p2.appendChild(createCopyButton(txt2.className))
+    p2.appendChild(createCopyButton(txt2.id))
     el.appendChild(p2)
 
     var a1 = document.createElement("a")
@@ -58,17 +56,17 @@ define(function () {
     p3.appendChild(t2)
     el.appendChild(p3)
 
-    function createCopyButton(name) {
+    function createCopyButton(id) {
         var btn = document.createElement("button")
         btn.className = "copy"
         btn.title = "Kopiere"
         btn.onclick = function() {
-            copy2clip(name)
+            copy2clip(id)
         }
         return btn
     }
-    function copy2clip(name) {
-        var copyTextarea = document.querySelector("." + name)
+    function copy2clip(id) {
+        var copyTextarea = document.querySelector("#" + id)
         copyTextarea.select()
         try {
             var successful = document.execCommand("copy")
@@ -79,15 +77,15 @@ define(function () {
         }
     }
     function switch2plain() {
-		var box1 = document.getElementById("area1")
+		var box1 = document.getElementById("location-latitude")
 		box1.value = d.lat.toFixed(5)
-		var box2 = document.getElementById("area2")
+		var box2 = document.getElementById("location-longitude")
 		box2.value = d.lng.toFixed(5)
     }
     function switch2uci() {
-        var box1 = document.getElementById("area1")
+        var box1 = document.getElementById("location-latitude")
 		box1.value = "uci set gluon-node-info.@location[0].latitude='" + d.lat.toFixed(5) + "'"
-		var box2 = document.getElementById("area2")
+		var box2 = document.getElementById("location-longitude")
 		box2.value = "uci set gluon-node-info.@location[0].longitude='" + d.lng.toFixed(5) + "'"
     }
   }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -253,6 +253,13 @@ button.close {
   }
 }
 
+button.copy {
+  margin-left: 10px;
+  &:after {
+    content: '\f41c';
+  }
+}
+
 .sidebar h2, .sidebar h3 {
   padding-left: $buttondistance;
   padding-right: $buttondistance;


### PR DESCRIPTION
Splitting the coords in latitude and longitude in 2 separate, named textareas solves confusion where to put each coord into luci.
This PR addresses https://github.com/freifunkMUC/meshviewer/issues/13
Now there is a button to copy those strings to clipboard directly.
Furthermore you can switch between plain coords and uci command for setting coords

Testing is welcome as it is expected that copy2clip() might not work with some older browser versions.