### PR TITLE
[TASK] Change the urls and strings for ffmuc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Meshviewer
-[![Build Status](https://img.shields.io/github/workflow/status/freifunk-ffm/meshviewer/Build%20Meshviewer?style=flat-square)](https://github.com/freifunk-ffm/meshviewer/actions?query=workflow%3A%22Build+Meshviewer%22)
-[![Release](https://img.shields.io/github/v/release/freifunk-ffm/meshviewer?style=flat-square)](https://github.com/freifunk-ffm/meshviewer/releases)
-[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/freifunk-ffm/meshviewer/develop.svg?style=flat-square)](https://scrutinizer-ci.com/g/freifunk-ffm/meshviewer/?branch=develop)
-[![License: AGPL v3](https://img.shields.io/github/license/freifunk-ffm/meshviewer.svg?style=flat-square)](https://www.gnu.org/licenses/agpl-3.0)
+[![Build Status](https://img.shields.io/github/workflow/status/freifunkMUC/meshviewer/Build%20Meshviewer?style=flat-square)](https://github.com/freifunkMUC/meshviewer/actions?query=workflow%3A%22Build+Meshviewer%22)
+[![Release](https://img.shields.io/github/v/release/freifunkMUC/meshviewer?style=flat-square)](https://github.com/freifunkMUC/meshviewer/releases)
+[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/freifunkMUC/meshviewer/develop.svg?style=flat-square)](https://scrutinizer-ci.com/g/freifunkMUC/meshviewer/?branch=develop)
+[![License: AGPL v3](https://img.shields.io/github/license/freifunkMUC/meshviewer.svg?style=flat-square)](https://www.gnu.org/licenses/agpl-3.0)
 
 Meshviewer is an online visualization app to represent nodes and links on a map for Freifunk open mesh network.
 
-** This is a fork of https://github.com/ffrgb/meshviewer with some adjustments **
+** This is a fork of https://github.com/freifunkMUC/meshviewer with some adjustments **
 
 ## Installation
 This fork of the new meshviewer has a new installation method:
-- Go to the [release page](https://github.com/freifunk-ffm/meshviewer/releases) and download the current build
+- Go to the [release page](https://github.com/freifunkMUC/meshviewer/releases) and download the current build
 - Let your webserver serve this build
 - Add a config.json to the webdir (based on config.json.example)
 

--- a/config.json.example
+++ b/config.json.example
@@ -2,7 +2,7 @@
     "dataPath": [
       "https://yanic.batman15.ffffm.net/"
     ],
-    "siteName": "Freifunk Frankfurt",
+    "siteName": "Freifunk München",
     "maxAge": 21,
     "nodeZoom": 19,
     "mapLayers": [
@@ -12,7 +12,7 @@
         "config": {
           "type": "osm",
           "maxZoom": 19,
-          "attribution": "<a href='https://github.com/freifunk-ffm/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
+          "attribution": "<a href='https://github.com/freifunkMUC/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
         }
       }
     ],

--- a/lib/about.js
+++ b/lib/about.js
@@ -18,8 +18,8 @@ define(function () {
         '</p>' +
         '<h3>Feel free to contribute!</h3>' +
         '<p>Please support this meshviewer-fork by opening issues or sending pull requests!</p>' +
-        '<p><a href="https://github.com/freifunk-ffm/meshviewer">' +
-        'https://github.com/freifunk-ffm/meshviewer</a></p>' +
+        '<p><a href="https://github.com/freifunkMUC/meshviewer">' +
+        'https://github.com/freifunkMUC/meshviewer</a></p>' +
         '<p>Fork maintained by Marvin Gaube</p>' +
         '<h3>AGPL 3</h3>' +
 
@@ -42,8 +42,8 @@ define(function () {
         'https://www.gnu.org/licenses/</a>.</p>' +
 
         '<p>The source code is available at ' +
-        '<a href="https://github.com/freifunk-ffm/meshviewer">' +
-        'https://github.com/freifunk-ffm/meshviewer</a>.</p>';
+        '<a href="https://github.com/freifunkMUC/meshviewer">' +
+        'https://github.com/freifunkMUC/meshviewer</a>.</p>';
     };
   };
 });

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/freifunk-ffm/meshviewer.git"
+    "url": "https://github.com/freifunkMUC/meshviewer.git"
   },
   "bugs": {
-    "url": "https://github.com/freifunk-ffm/meshviewer/issues"
+    "url": "https://github.com/freifunkMUC/meshviewer/issues"
   },
   "devDependencies": {
     "audit-ci": "^2.5.1",


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Updated String & URLs to point to ffmuc instead of ffm.
config.json.example hasn't been fully updated yet. Waiting for the official ffmuc config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enable compatibility with the existing freifunk munich infrastructure

## How Has This Been Tested?
<!--- Please try to test the code in multiple browsers and also on a mobile device -->
Hasn't been tested yet as the config is still missing.

## Screenshots/links (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
