### PR TITLE
change "soon" to "now" in dreprecation warning

### DIFF
--- a/config.json
+++ b/config.json
@@ -369,6 +369,6 @@
       }
    ],
 
-    "deprecation_text": "Dieses Gerät ist leider veraltet und wird bald nicht mehr durch Software-Updates unterstützt - <a href='https://ffmuc.net/freifunkmuc/2019/07/11/austausch-aelterer-geraete/'>Mehr Infos</a>",
+    "deprecation_text": "Dieses Gerät ist leider veraltet und wird nicht mehr durch Software-Updates unterstützt - <a href='https://ffmuc.net/freifunkmuc/2019/07/11/austausch-aelterer-geraete/'>Mehr Infos</a>",
     "deprecation_enabled": true
 }


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description
The devices have been deprecated mid-2022. Updating the message.

## Motivation and Context

Message is outdated, updating it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please try to test the code in multiple browsers and also on a mobile device -->

## Screenshots/links (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
