### PR TITLE
Add ffmuc_ffdon_test

### DIFF
--- a/config.json
+++ b/config.json
@@ -330,6 +330,10 @@
          "name": "FFMUC Freising"
       },
       {
+         "domain": "ffmuc_ffdon_test",
+         "name": "Freifunk Donau-Ries Test"
+      },
+      {
          "domain": "ffmuc_unifi_respondd_fallback",
          "name": "FFMUC UniFi Fallback"
       },


### PR DESCRIPTION
This adds the domain `ffmuc_ffdon_test` for testing new FFDON firmware with FFMUC gateways.