### PR TITLE
 [TASK]: add EdgeRouter models to deprecated dev list

### DIFF
--- a/config.json
+++ b/config.json
@@ -531,6 +531,8 @@
        "TP-Link TL-WR902AC v3",
        "TP-Link WBS210 v1.20",
        "TP-Link WBS210 v2",
-       "TP-Link WBS510 v1"
+       "TP-Link WBS510 v1",
+       "Ubiquiti EdgeRouter X",
+       "Ubiquiti EdgeRouter X SFP"
     ]
  }


### PR DESCRIPTION
ref: https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka#migrating_to_2410x

<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

<!-- Describe your changes -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
