### PR TITLE
Drop D-Link DGS-1210 and Xiaomi Redmi Router AX6S

### DIFF
--- a/config.json
+++ b/config.json
@@ -517,6 +517,7 @@
     "TP-Link WBS210 v2",
     "TP-Link WBS510 v1",
     "Ubiquiti EdgeRouter X",
-    "Ubiquiti EdgeRouter X SFP"
+    "Ubiquiti EdgeRouter X SFP",
+    "Xiaomi Redmi Router AX6S"
   ]
 }

--- a/config.json
+++ b/config.json
@@ -484,6 +484,7 @@
     "VoCore 16M"
   ],
   "deprecated": [
+    "D-Link DGS-1210",
     "TP-Link Archer C2 v3",
     "TP-Link Archer C6 v2 (EU/RU/JP)",
     "TP-Link Archer C6 v2",


### PR DESCRIPTION
- D-Link DGS-1210 is deprecated: https://github.com/freifunk-gluon/gluon/commit/4e847f7eef8ce143afd8ade72b56d9f49013e414

- Xiaomi Redmi Router AX6S is deprecated: Due to too small kernel partition in stuck ubi layout. See https://github.com/freifunk-gluon/gluon/commit/35b70fcea274b847cc1d46bd058868312748790c