### PR TITLE
config: enable Grafana node charts (clients + traffic)

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,38 @@
   "clientZoom": 15,
   "fullscreen": true,
   "fullscreenFrame": true,
+  "grafana": {
+    "url": "https://stats.ffmuc.net",
+    "orgId": 1
+  },
+  "nodeCharts": [
+    {
+      "name": "Clients",
+      "datasourceUid": "000000005",
+      "datasourceType": "influxdb",
+      "query": "SELECT mean(\"clients.total\") AS \"Clients\" FROM \"node\" WHERE (\"nodeid\" =~ /^$node$/) AND $timeFilter GROUP BY time($interval) fill(null)",
+      "format": ".0f",
+      "from": "now-7d",
+      "to": "now-1m",
+      "maxDataPoints": 300,
+      "series": [{ "name": "Clients", "color": "#73BF69" }]
+    },
+    {
+      "name": "Traffic",
+      "datasourceUid": "000000005",
+      "datasourceType": "influxdb",
+      "query": "SELECT non_negative_derivative(mean(\"traffic.rx.bytes\"), 1s) * 8 AS \"RX\", non_negative_derivative(mean(\"traffic.tx.bytes\"), 1s) * 8 AS \"TX\" FROM \"node\" WHERE (\"nodeid\" =~ /^$node$/) AND $timeFilter GROUP BY time($interval) fill(none)",
+      "format": ".2~s",
+      "unitSuffix": "bit/s",
+      "from": "now-7d",
+      "to": "now-1m",
+      "maxDataPoints": 300,
+      "series": [
+        { "name": "RX", "color": "#73BF69" },
+        { "name": "TX", "color": "#F2495C", "negate": true }
+      ]
+    }
+  ],
   "nodeAttr": [
     {
       "name": "node.status",


### PR DESCRIPTION
## What

Enables the client-side rendered node charts in production by adding Grafana config to `config.json`:

- `grafana.url` → `https://stats.ffmuc.net` (org 1)
- `nodeCharts`:
  - **Clients** — `mean("clients.total")` from the `node` measurement
  - **Traffic** — RX/TX from `non_negative_derivative(...) * 8` (bit/s), TX negated

Datasource: the FFMUC **yanic** InfluxDB datasource (`uid 000000005`).

## How it works

This relies on the existing `lib/infobox/chart.ts` machinery (added in #… "add client side rendered charts"), which queries Grafana's `/api/ds/query` HTTP API directly and draws the series with D3 — **no Grafana image render plugin needed**. This mirrors how [freifunk-map-modern](https://github.com/freifunkMUC/freifunk-map-modern) pulls raw series from Grafana/InfluxDB and renders them itself.

## Verification

I verified the exact request `chart.ts` issues works against the live Grafana anonymously:

- `clients.total` query → HTTP 200, real per-node data, macros (`$node`, `$timeFilter`, `$interval`) interpolated, frame name `node.Clients` (parses correctly).
- Traffic derivative query → HTTP 200, two frames `node.RX` / `node.TX` with 288 points each.

> [!NOTE]
> The browser must reach `stats.ffmuc.net` on a CORS-enabled or same-origin basis. `stats.ffmuc.net` currently does not send CORS headers, so for the direct-URL setup in this PR to work in the browser, the Grafana server needs CORS allowed for the map origin (or a same-origin reverse-proxy path can be used by setting `grafana.url` to e.g. `/grafana`).

Only `config.json` is changed.