### PR TITLE
infobox/chart: support InfluxDB ALIAS BY for multi-series queries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "actions"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "npm"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "docker"
+    exclude-paths:
+      # FFMuc uses ".yaml" not ".yml"
+      - ".github/workflows/*.yml"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: npm run build
       - run: cp config.json build/
       - name: rsync deployments
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@v8
         with:
           switches: -avzr --delete --exclude .ssh
           path: build/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [webfrontend03, webfrontend04, webfrontend05, webfrontend06]
-        node-version: [20.x]
+        node-version: [24.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,32 @@
+name: DEPLOY
+on:
+  push:
+    branches:
+      - main
+jobs:
+  map-deploy:
+    if: github.repository_owner == 'freifunkMUC'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [webfrontend03, webfrontend04, webfrontend05, webfrontend06]
+        node-version: [20.x]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build
+      - run: cp config.json build/
+      - name: rsync deployments
+        uses: burnett01/rsync-deployments@5.2
+        with:
+          switches: -avzr --delete --exclude .ssh
+          path: build/
+          remote_path: /srv/www/map.ffmuc.net/
+          remote_host: ${{ matrix.target }}.ext.ffmuc.net
+          remote_user: deploy-map
+          remote_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,8 +1,6 @@
 name: Publish Docker image
 on:
   push:
-    branches:
-      - "main"
     tags:
       - "v*.*.*"
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @freifunkMUC/meshviewer

--- a/config.json
+++ b/config.json
@@ -517,6 +517,7 @@
     "TP-Link WBS210 v2",
     "TP-Link WBS510 v1",
     "Ubiquiti EdgeRouter X",
-    "Ubiquiti EdgeRouter X SFP"
+    "Ubiquiti EdgeRouter X SFP",
+    "Xiaomi Redmi Router AX6S"
   ]
 }

--- a/config.json
+++ b/config.json
@@ -484,6 +484,7 @@
     "VoCore 16M"
   ],
   "deprecated": [
+    "D-Link DGS-1210",
     "TP-Link Archer C2 v3",
     "TP-Link Archer C6 v2 (EU/RU/JP)",
     "TP-Link Archer C6 v2",

--- a/config.json
+++ b/config.json
@@ -220,6 +220,15 @@
       }
     },
     {
+      "name": "FFMUC OSM Proxy (Night)",
+      "url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
+      "config": {
+        "maxZoom": 19,
+        "mode": "night",
+        "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+      }
+    },
+    {
       "name": "FFMUC OSM.HOT Proxy",
       "url": "https://tiles.ext.ffmuc.net/hot/{z}/{x}/{y}.png",
       "config": {

--- a/config.json
+++ b/config.json
@@ -1,536 +1,521 @@
 {
-    "reverseGeocodingApi": "https://nominatim.openstreetmap.org/reverse",
-    "maxAge": 7,
-    "maxAgeAlert": 3,
-    "nodeZoom": 18,
-    "labelZoom": 13,
-    "clientZoom": 15,
-    "fullscreen": true,
-    "fullscreenFrame": true,
-    "nodeAttr": [
-       {
-          "name": "node.status",
-          "value": "Status"
-       },
-       {
-          "name": "node.gateway",
-          "value": "Gateway"
-       },
-       {
-          "name": "node.coordinates",
-          "value": "GeoURI"
-       },
-       {
-          "name": "node.contact",
-          "value": "owner"
-       },
-       {
-          "name": "node.hardware",
-          "value": "model"
-       },
-       {
-          "name": "node.primaryMac",
-          "value": "mac"
-       },
-       {
-          "name": "node.firmware",
-          "value": "Firmware"
-       },
-       {
-          "name": "node.uptime",
-          "value": "Uptime"
-       },
-       {
-          "name": "node.firstSeen",
-          "value": "FirstSeen"
-       },
-       {
-          "name": "node.systemLoad",
-          "value": "Load"
-       },
-       {
-          "name": "node.ram",
-          "value": "RAM"
-       },
-       {
-          "name": "node.ipAddresses",
-          "value": "IPs"
-       },
-       {
-          "name": "node.update",
-          "value": "Autoupdate"
-       },
-       {
-          "name": "node.domain",
-          "value": "Domain"
-       },
-       {
-          "name": "node.clients",
-          "value": "Clients"
-       }
-    ],
-    "supportedLocale": [
-       "en",
-       "de",
-       "cz",
-       "fr",
-       "tr",
-       "ru"
-    ],
-    "icon": {
-       "base": {
-          "fillOpacity": 0.6,
-          "opacity": 0.6,
-          "weight": 2,
-          "radius": 6,
-          "className": "stroke-first"
-       },
-       "online": {
-          "color": "#1566A9",
-          "fillColor": "#1566A9"
-       },
-       "offline": {
-          "color": "#D43E2A",
-          "fillColor": "#D43E2A",
-          "radius": 3
-       },
-       "lost": {
-          "color": "#D43E2A",
-          "fillColor": "#D43E2A",
-          "radius": 4
-       },
-       "alert": {
-          "color": "#D43E2A",
-          "fillColor": "#D43E2A",
-          "radius": 5
-       },
-       "new": {
-          "color": "#1566A9",
-          "fillColor": "#93E929"
-       }
+  "reverseGeocodingApi": "https://nominatim.openstreetmap.org/reverse",
+  "maxAge": 7,
+  "maxAgeAlert": 3,
+  "nodeZoom": 18,
+  "labelZoom": 13,
+  "clientZoom": 15,
+  "fullscreen": true,
+  "fullscreenFrame": true,
+  "nodeAttr": [
+    {
+      "name": "node.status",
+      "value": "Status"
     },
-    "client": {
-       "wifi24": "rgba(220, 0, 103, 0.7)",
-       "wifi5": "rgba(10, 156, 146, 0.7)",
-       "other": "rgba(227, 166, 25, 0.7)"
+    {
+      "name": "node.gateway",
+      "value": "Gateway"
     },
-    "map": {
-       "labelNewColor": "#459c18",
-       "tqFrom": "#F02311",
-       "tqTo": "#04C714",
-       "highlightNode": {
-          "color": "#ad2358",
-          "weight": 8,
-          "fillOpacity": 1,
-          "opacity": 0.4,
-          "className": "stroke-first"
-       },
-       "highlightLink": {
-          "weight": 4,
-          "opacity": 1,
-          "dashArray": "5, 10"
-       }
+    {
+      "name": "node.coordinates",
+      "value": "GeoURI"
     },
-    "forceGraph": {
-       "nodeColor": "#fff",
-       "nodeOfflineColor": "#D43E2A",
-       "highlightColor": "rgba(255, 255, 255, 0.2)",
-       "labelColor": "#fff",
-       "tqFrom": "#770038",
-       "tqTo": "#dc0067",
-       "zoomModifier": 1
+    {
+      "name": "node.contact",
+      "value": "owner"
     },
-    "locate": {
-       "outerCircle": {
-          "stroke": false,
-          "color": "#4285F4",
-          "opacity": 1,
-          "fillOpacity": 0.3,
-          "clickable": false,
-          "radius": 16
-       },
-       "innerCircle": {
-          "stroke:": true,
-          "color": "#ffffff",
-          "fillColor": "#4285F4",
-          "weight": 1.5,
-          "clickable": false,
-          "opacity": 1,
-          "fillOpacity": 1,
-          "radius": 7
-       },
-       "accuracyCircle": {
-          "stroke": true,
-          "color": "#4285F4",
-          "weight": 1,
-          "clickable": false,
-          "opacity": 0.7,
-          "fillOpacity": 0.2
-       }
+    {
+      "name": "node.hardware",
+      "value": "model"
     },
-    "cacheBreaker": "22967a527",
-    "nodeInfos": [
-       {
-          "name": "Clients (24 Stunden)",
-          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?orgId=1&panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-24h",
-          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-          "title": "Clients - Knoten {NODE_ID}"
-       },
-       {
-          "name": "Traffic (24 Stunden)",
-          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-24h",
-          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-          "title": "Traffic - Knoten {NODE_ID}"
-       },
-       {
-          "name": "Clients (7 Tage)",
-          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-7d",
-          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-          "title": "Clients - Knoten {NODE_ID}"
-       },
-       {
-          "name": "Traffic (7 Tage)",
-          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
-          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-          "title": "Traffic - Knoten {NODE_ID}"
-       },
-       {
-          "name": "Uptime (7 Tage)",
-          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=8&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
-          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-          "title": "Traffic - Knoten {NODE_ID}"
-       }
-    ],
-    "globalInfos": [
-       {
-          "name": "Clients",
-          "title": "Clients pro Segment",
-          "href": "https://stats.ffmuc.net",
-          "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=6&orgId=1&theme=light&width=500&height=500"
-       },
-       {
-          "name": "Traffic",
-          "title": "Traffic pro Server",
-          "href": "https://stats.ffmuc.net",
-          "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=7&orgId=1&theme=light&width=500&height=500"
-       }
-    ],
-    "dataPath": [
-       "https://map.ffmuc.net/data/"
-    ],
-    "siteName": "Freifunk München",
-    "mapLayers": [
-       {
-          "name": "FFMUC OSM Proxy",
-          "url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
-          "config": {
-             "maxZoom": 19,
-             "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
-          }
-       },
-       {
-          "name": "FFMUC OSM.HOT Proxy",
-          "url": "https://tiles.ext.ffmuc.net/hot/{z}/{x}/{y}.png",
-          "config": {
-             "maxZoom": 20,
-             "attribution": "&copy; Openstreetmap France | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
-          }
-       },
-       {
-          "name": "Esri.WorldImagery",
-          "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-          "config": {
-             "maxZoom": 20,
-             "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
-          }
-       }
-    ],
-    "backup_map_provider_ffmuc": [
-       {
-          "name": "HERE",
-          "url": "https://{s}.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?app_id=YOUR_KEY&app_code=YOUR_CODE&lg=deu",
-          "config": {
-             "attribution": "Map &copy; 1987-2014 <a href=\"http://developer.here.com\">HERE</a>",
-             "subdomains": "1234",
-             "maxZoom": 20
-          }
-       },
-       {
-          "name": "HERE.hybridDay",
-          "url": "https://{s}.aerial.maps.api.here.com/maptile/2.1/maptile/newest/{variant}/{z}/{x}/{y}/256/png8?app_id=YOUR_KEY&app_code=YOUR_CODE&lg=deu",
-          "config": {
-             "attribution": "Map &copy; 1987-2014 <a href=\"http://developer.here.com\">HERE</a>",
-             "subdomains": "1234",
-             "variant": "hybrid.day",
-             "maxZoom": 20
-          }
-       }
-    ],
-    "fixedCenter": [
-       [
-          48.3957886,
-          12.012732
-       ],
-       [
-          48.0428527,
-          11.2707154
-       ]
-    ],
-    "domainNames": [
-       {
-          "domain": "",
-          "name": "Unknown Domain"
-       },
-       {
-          "domain": "ffdon_mitte",
-          "name": "Donau-Ries - Mitte"
-       },
-       {
-          "domain": "ffdon_nordwest",
-          "name": "Donau-Ries - Nordwest"
-       },
-       {
-          "domain": "ffdon_sued",
-          "name": "Donau-Ries - Süd"
-       },
-       {
-          "domain": "ffmuc_muc_cty",
-          "name": "München - Stadt"
-       },
-       {
-          "domain": "ffmuc_muc_nord",
-          "name": "München - Nord"
-       },
-       {
-          "domain": "ffmuc_muc_ost",
-          "name": "München - Ost"
-       },
-       {
-          "domain": "ffmuc_muc_sued",
-          "name": "München - Süd"
-       },
-       {
-          "domain": "ffmuc_muc_west",
-          "name": "München - West"
-       },
-       {
-          "domain": "ffmuc_uml_nord",
-          "name": "Bayern - Südnord"
-       },
-       {
-          "domain": "ffmuc_uml_ost",
-          "name": "Bayern - Südost"
-       },
-       {
-          "domain": "ffmuc_uml_sued",
-          "name": "Bayern - Südsüd"
-       },
-       {
-          "domain": "ffmuc_uml_west",
-          "name": "Bayern - Südwest"
-       },
-       {
-          "domain": "ffmuc_welt",
-          "name": "Welt"
-       },
-       {
-          "domain": "ffmuc_augsburg",
-          "name": "Augsburg"
-       },
-       {
-          "domain": "ffmuc_gauting",
-          "name": "Gauting"
-       },
-       {
-          "domain": "ffmuc_freising",
-          "name": "Freising"
-       },
-       {
-         "domain": "ffmuc_ulm",
-         "name": "Ulm"
-       },
-       {
-          "domain": "ffwert_city",
-          "name": "Wertingen - City"
-       },
-       {
-          "domain": "ffwert_events",
-          "name": "Wertingen - Events"
-       },
-       {
-          "domain": "ffmuc_unifi_respondd_fallback",
-          "name": "UniFi"
-       },
-       {
-          "domain": "omada_respondd_fallback",
-          "name": "Omada"
-       }
-    ],
-    "linkList": [
-       {
-          "title": "Chat",
-          "href": "https://chat.ffmuc.net"
-       },
-       {
-          "title": "Tickets",
-          "href": "https://tickets.ffmuc.net"
-       },
-       {
-          "title": "Statistiken",
-          "href": "https://stats.ffmuc.net"
-       },
-       {
-          "title": "Kontakt",
-          "href": "https://ffmuc.net/kontakt"
-       },
-       {
-          "title": "Impressum",
-          "href": "https://ffmuc.net/impressum/"
-       }
-    ],
-     "devicePictures": "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
-     "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
-     "devicePicturesLicense": "CC-BY-NC-SA 4.0",
-    "deprecation_text": "Dieses Gerät ist leider veraltet und wird voraussichtlich nach 2025 nicht mehr durch Software-Updates unterstützt - <a href='https://ffmuc.net/freifunkmuc/2023/12/08/supportende-von-8-64-routern/'>Mehr Infos</a>",
-    "eol_text": "Dieses Gerät ist leider veraltet und wird nicht mehr durch Software-Updates unterstützt - <a href='https://bitte-router-erneuern.ffmuc.net/'>Mehr Infos</a>",
-    "deprecation_enabled": true,
-    "eol": [
-      "A5-V11",
-      "AP121",
-      "AP121U",
-      "D-Link DIR-615",
-      "D-Link DIR-615 D",
-      "D-Link DIR-825",
-      "AVM FRITZ!Box 7320",
-      "AVM FRITZ!Box 7330",
-      "AVM FRITZ!Box 7330 SL",
-      "TP-Link RE200 v1",
-      "TP-Link RE200 v2",
-      "TP-Link RE200 v3",
-      "TP-Link RE200 v4",
-      "TP-Link RE305 v1",
-      "TP-Link RE305 v2",
-      "TP-Link RE305 v3",
-      "TP-Link RE355 v1",
-      "TP-Link RE450 v1",
-      "TP-Link RE450 v2",
-      "TP-Link RE450 v3",
-      "TP-Link TL-MR13U v1",
-      "TP-Link TL-MR3020 v1",
-      "TP-Link TL-MR3040 v1",
-      "TP-Link TL-MR3040 v2",
-      "TP-Link TL-MR3220 v1",
-      "TP-Link TL-MR3220 v2",
-      "TP-Link TL-MR3420 v1",
-      "TP-Link TL-MR3420 v2",
-      "TP-Link TL-WA701N/ND v1",
-      "TP-Link TL-WA701N/ND v2",
-      "TP-Link TL-WA730RE v1",
-      "TP-Link TL-WA750RE v1",
-      "TP-Link TL-WA801N/ND v1",
-      "TP-Link TL-WA801N/ND v2",
-      "TP-Link TL-WA801N/ND v3",
-      "TP-Link TL-WA830RE v1",
-      "TP-Link TL-WA830RE v2",
-      "TP-Link TL-WA850RE v1",
-      "TP-Link TL-WA860RE v1",
-      "TP-Link TL-WA901N/ND v1",
-      "TP-Link TL-WA901N/ND v2",
-      "TP-Link TL-WA901N/ND v3",
-      "TP-Link TL-WA901N/ND v4",
-      "TP-Link TL-WA901N/ND v5",
-      "TP-Link TL-WA7210N v2",
-      "TP-Link TL-WA7510N v1",
-      "TP-Link TL-WR703N v1",
-      "TP-Link TL-WR710N v1",
-      "TP-Link TL-WR710N v2",
-      "TP-Link TL-WR710N v2.1",
-      "TP-Link TL-WR740N/ND v1",
-      "TP-Link TL-WR740N/ND v3",
-      "TP-Link TL-WR740N/ND v4",
-      "TP-Link TL-WR740N/ND v5",
-      "TP-Link TL-WR741N/ND v1",
-      "TP-Link TL-WR741N/ND v3",
-      "TP-Link TL-WR741N/ND v4",
-      "TP-Link TL-WR741N/ND v5",
-      "TP-Link TL-WR743N/ND v1",
-      "TP-Link TL-WR743N/ND v2",
-      "TP-Link TL-WR840N v2",
-      "TP-Link TL-WR841N/ND v3",
-      "TP-Link TL-WR841N/ND v5",
-      "TP-Link TL-WR841N/ND v7",
-      "TP-Link TL-WR841N/ND v8",
-      "TP-Link TL-WR841N/ND v9",
-      "TP-Link TL-WR841N/ND v10",
-      "TP-Link TL-WR841N/ND v11",
-      "TP-Link TL-WR841N/ND v12",
-      "TP-Link TL-WR841N/ND Mod (16M) v11",
-      "TP-Link TL-WR841N/ND Mod (16M) v10",
-      "TP-Link TL-WR841N/ND Mod (16M) v8",
-      "TP-Link TL-WR841N/ND Mod (16M) v9",
-      "TP-Link TL-WR841N/ND Mod (8M) v10",
-      "TP-Link TL-WR842N/ND v1",
-      "TP-Link TL-WR842N/ND v2",
-      "TP-Link TL-WR843N/ND v1",
-      "TP-Link TL-WR940N v1",
-      "TP-Link TL-WR940N v2",
-      "TP-Link TL-WR940N v3",
-      "TP-Link TL-WR940N v4",
-      "TP-Link TL-WR940N v5",
-      "TP-Link TL-WR940N v6",
-      "TP-Link TL-WR941N/ND v2",
-      "TP-Link TL-WR941N/ND v3",
-      "TP-Link TL-WR941N/ND v4",
-      "TP-Link TL-WR941N/ND v5",
-      "TP-Link TL-WR941N/ND v6",
-      "TP-Link TL-WR1043N/ND v1",
-      "D-Link DIR-615 D1",
-      "D-Link DIR-615 D2",
-      "D-Link DIR-615 D3",
-      "D-Link DIR-615 D4",
-      "D-Link DIR-615 H1",
-      "Ubiquiti NanoStation loco M2",
-      "Ubiquiti NanoStation M2",
-      "Ubiquiti PicoStation M2",
-      "Ubiquiti Bullet M",
-      "Ubiquiti Bullet M2",
-      "Ubiquiti AirRouter",
-      "VoCore 8M",
-      "VoCore 16M"
-    ],
-    "deprecated": [
-       "TP-Link Archer C2 v3",
-       "TP-Link Archer C6 v2 (EU/RU/JP)",
-       "TP-Link Archer C6 v2",
-       "TP-Link Archer C6 v3",
-       "TP-Link Archer C20 v4",
-       "TP-Link Archer C20i",
-       "TP-Link Archer C25 v1",
-       "TP-Link Archer C50 v1",
-       "TP-Link Archer C50 v3",
-       "TP-Link Archer C50 v4",
-       "TP-Link Archer C50 v6",
-       "TP-Link Archer C60 v1",
-       "TP-Link Archer C60 v2",
-       "TP-Link CPE210 v1.0",
-       "TP-Link CPE210 v1.1",
-       "TP-Link CPE210 v1",
-       "TP-Link CPE210 v2.0",
-       "TP-Link CPE210 v2",
-       "TP-Link CPE210 v3.0",
-       "TP-Link CPE210 v3.20",
-       "TP-Link CPE210 v3",
-       "TP-Link CPE510 v1.0",
-       "TP-Link CPE510 v1.1",
-       "TP-Link CPE510 v1",
-       "TP-Link CPE510 v2",
-       "TP-Link CPE510 v3",
-       "TP-Link TL-WR902AC v1",
-       "TP-Link TL-WR902AC v3",
-       "TP-Link WBS210 v1.20",
-       "TP-Link WBS210 v2",
-       "TP-Link WBS510 v1",
-       "Ubiquiti EdgeRouter X",
-       "Ubiquiti EdgeRouter X SFP"
-    ]
- }
+    {
+      "name": "node.primaryMac",
+      "value": "mac"
+    },
+    {
+      "name": "node.firmware",
+      "value": "Firmware"
+    },
+    {
+      "name": "node.uptime",
+      "value": "Uptime"
+    },
+    {
+      "name": "node.firstSeen",
+      "value": "FirstSeen"
+    },
+    {
+      "name": "node.systemLoad",
+      "value": "Load"
+    },
+    {
+      "name": "node.ram",
+      "value": "RAM"
+    },
+    {
+      "name": "node.ipAddresses",
+      "value": "IPs"
+    },
+    {
+      "name": "node.update",
+      "value": "Autoupdate"
+    },
+    {
+      "name": "node.domain",
+      "value": "Domain"
+    },
+    {
+      "name": "node.clients",
+      "value": "Clients"
+    }
+  ],
+  "supportedLocale": ["en", "de", "cz", "fr", "tr", "ru"],
+  "icon": {
+    "base": {
+      "fillOpacity": 0.6,
+      "opacity": 0.6,
+      "weight": 2,
+      "radius": 6,
+      "className": "stroke-first"
+    },
+    "online": {
+      "color": "#1566A9",
+      "fillColor": "#1566A9"
+    },
+    "offline": {
+      "color": "#D43E2A",
+      "fillColor": "#D43E2A",
+      "radius": 3
+    },
+    "lost": {
+      "color": "#D43E2A",
+      "fillColor": "#D43E2A",
+      "radius": 4
+    },
+    "alert": {
+      "color": "#D43E2A",
+      "fillColor": "#D43E2A",
+      "radius": 5
+    },
+    "new": {
+      "color": "#1566A9",
+      "fillColor": "#93E929"
+    }
+  },
+  "client": {
+    "wifi24": "rgba(220, 0, 103, 0.7)",
+    "wifi5": "rgba(10, 156, 146, 0.7)",
+    "other": "rgba(227, 166, 25, 0.7)"
+  },
+  "map": {
+    "labelNewColor": "#459c18",
+    "tqFrom": "#F02311",
+    "tqTo": "#04C714",
+    "highlightNode": {
+      "color": "#ad2358",
+      "weight": 8,
+      "fillOpacity": 1,
+      "opacity": 0.4,
+      "className": "stroke-first"
+    },
+    "highlightLink": {
+      "weight": 4,
+      "opacity": 1,
+      "dashArray": "5, 10"
+    }
+  },
+  "forceGraph": {
+    "nodeColor": "#fff",
+    "nodeOfflineColor": "#D43E2A",
+    "highlightColor": "rgba(255, 255, 255, 0.2)",
+    "labelColor": "#fff",
+    "tqFrom": "#770038",
+    "tqTo": "#dc0067",
+    "zoomModifier": 1
+  },
+  "locate": {
+    "outerCircle": {
+      "stroke": false,
+      "color": "#4285F4",
+      "opacity": 1,
+      "fillOpacity": 0.3,
+      "clickable": false,
+      "radius": 16
+    },
+    "innerCircle": {
+      "stroke:": true,
+      "color": "#ffffff",
+      "fillColor": "#4285F4",
+      "weight": 1.5,
+      "clickable": false,
+      "opacity": 1,
+      "fillOpacity": 1,
+      "radius": 7
+    },
+    "accuracyCircle": {
+      "stroke": true,
+      "color": "#4285F4",
+      "weight": 1,
+      "clickable": false,
+      "opacity": 0.7,
+      "fillOpacity": 0.2
+    }
+  },
+  "cacheBreaker": "22967a527",
+  "nodeInfos": [
+    {
+      "name": "Clients (24 Stunden)",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?orgId=1&panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-24h",
+      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+      "title": "Clients - Knoten {NODE_ID}"
+    },
+    {
+      "name": "Traffic (24 Stunden)",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-24h",
+      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+      "title": "Traffic - Knoten {NODE_ID}"
+    },
+    {
+      "name": "Clients (7 Tage)",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-7d",
+      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+      "title": "Clients - Knoten {NODE_ID}"
+    },
+    {
+      "name": "Traffic (7 Tage)",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
+      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+      "title": "Traffic - Knoten {NODE_ID}"
+    },
+    {
+      "name": "Uptime (7 Tage)",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=8&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
+      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+      "title": "Traffic - Knoten {NODE_ID}"
+    }
+  ],
+  "globalInfos": [
+    {
+      "name": "Clients",
+      "title": "Clients pro Segment",
+      "href": "https://stats.ffmuc.net",
+      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=6&orgId=1&theme=light&width=500&height=500"
+    },
+    {
+      "name": "Traffic",
+      "title": "Traffic pro Server",
+      "href": "https://stats.ffmuc.net",
+      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=7&orgId=1&theme=light&width=500&height=500"
+    }
+  ],
+  "dataPath": ["https://map.ffmuc.net/data/"],
+  "siteName": "Freifunk München",
+  "mapLayers": [
+    {
+      "name": "FFMUC OSM Proxy",
+      "url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
+      "config": {
+        "maxZoom": 19,
+        "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+      }
+    },
+    {
+      "name": "FFMUC OSM.HOT Proxy",
+      "url": "https://tiles.ext.ffmuc.net/hot/{z}/{x}/{y}.png",
+      "config": {
+        "maxZoom": 20,
+        "attribution": "&copy; Openstreetmap France | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+      }
+    },
+    {
+      "name": "Esri.WorldImagery",
+      "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      "config": {
+        "maxZoom": 20,
+        "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+      }
+    }
+  ],
+  "backup_map_provider_ffmuc": [
+    {
+      "name": "HERE",
+      "url": "https://{s}.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?app_id=YOUR_KEY&app_code=YOUR_CODE&lg=deu",
+      "config": {
+        "attribution": "Map &copy; 1987-2014 <a href=\"http://developer.here.com\">HERE</a>",
+        "subdomains": "1234",
+        "maxZoom": 20
+      }
+    },
+    {
+      "name": "HERE.hybridDay",
+      "url": "https://{s}.aerial.maps.api.here.com/maptile/2.1/maptile/newest/{variant}/{z}/{x}/{y}/256/png8?app_id=YOUR_KEY&app_code=YOUR_CODE&lg=deu",
+      "config": {
+        "attribution": "Map &copy; 1987-2014 <a href=\"http://developer.here.com\">HERE</a>",
+        "subdomains": "1234",
+        "variant": "hybrid.day",
+        "maxZoom": 20
+      }
+    }
+  ],
+  "fixedCenter": [
+    [48.3957886, 12.012732],
+    [48.0428527, 11.2707154]
+  ],
+  "domainNames": [
+    {
+      "domain": "",
+      "name": "Unknown Domain"
+    },
+    {
+      "domain": "ffdon_mitte",
+      "name": "Donau-Ries - Mitte"
+    },
+    {
+      "domain": "ffdon_nordwest",
+      "name": "Donau-Ries - Nordwest"
+    },
+    {
+      "domain": "ffdon_sued",
+      "name": "Donau-Ries - Süd"
+    },
+    {
+      "domain": "ffmuc_muc_cty",
+      "name": "München - Stadt"
+    },
+    {
+      "domain": "ffmuc_muc_nord",
+      "name": "München - Nord"
+    },
+    {
+      "domain": "ffmuc_muc_ost",
+      "name": "München - Ost"
+    },
+    {
+      "domain": "ffmuc_muc_sued",
+      "name": "München - Süd"
+    },
+    {
+      "domain": "ffmuc_muc_west",
+      "name": "München - West"
+    },
+    {
+      "domain": "ffmuc_uml_nord",
+      "name": "Bayern - Südnord"
+    },
+    {
+      "domain": "ffmuc_uml_ost",
+      "name": "Bayern - Südost"
+    },
+    {
+      "domain": "ffmuc_uml_sued",
+      "name": "Bayern - Südsüd"
+    },
+    {
+      "domain": "ffmuc_uml_west",
+      "name": "Bayern - Südwest"
+    },
+    {
+      "domain": "ffmuc_welt",
+      "name": "Welt"
+    },
+    {
+      "domain": "ffmuc_augsburg",
+      "name": "Augsburg"
+    },
+    {
+      "domain": "ffmuc_gauting",
+      "name": "Gauting"
+    },
+    {
+      "domain": "ffmuc_freising",
+      "name": "Freising"
+    },
+    {
+      "domain": "ffmuc_ulm",
+      "name": "Ulm"
+    },
+    {
+      "domain": "ffwert_city",
+      "name": "Wertingen - City"
+    },
+    {
+      "domain": "ffwert_events",
+      "name": "Wertingen - Events"
+    },
+    {
+      "domain": "ffmuc_unifi_respondd_fallback",
+      "name": "UniFi"
+    },
+    {
+      "domain": "omada_respondd_fallback",
+      "name": "Omada"
+    }
+  ],
+  "linkList": [
+    {
+      "title": "Chat",
+      "href": "https://chat.ffmuc.net"
+    },
+    {
+      "title": "Tickets",
+      "href": "https://tickets.ffmuc.net"
+    },
+    {
+      "title": "Statistiken",
+      "href": "https://stats.ffmuc.net"
+    },
+    {
+      "title": "Kontakt",
+      "href": "https://ffmuc.net/kontakt"
+    },
+    {
+      "title": "Impressum",
+      "href": "https://ffmuc.net/impressum/"
+    }
+  ],
+  "devicePictures": "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
+  "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
+  "devicePicturesLicense": "CC-BY-NC-SA 4.0",
+  "deprecation_text": "Dieses Gerät ist leider veraltet und wird voraussichtlich nach 2025 nicht mehr durch Software-Updates unterstützt - <a href='https://ffmuc.net/freifunkmuc/2023/12/08/supportende-von-8-64-routern/'>Mehr Infos</a>",
+  "eol_text": "Dieses Gerät ist leider veraltet und wird nicht mehr durch Software-Updates unterstützt - <a href='https://bitte-router-erneuern.ffmuc.net/'>Mehr Infos</a>",
+  "deprecation_enabled": true,
+  "eol": [
+    "A5-V11",
+    "AP121",
+    "AP121U",
+    "D-Link DIR-615",
+    "D-Link DIR-615 D",
+    "D-Link DIR-825",
+    "AVM FRITZ!Box 7320",
+    "AVM FRITZ!Box 7330",
+    "AVM FRITZ!Box 7330 SL",
+    "TP-Link RE200 v1",
+    "TP-Link RE200 v2",
+    "TP-Link RE200 v3",
+    "TP-Link RE200 v4",
+    "TP-Link RE305 v1",
+    "TP-Link RE305 v2",
+    "TP-Link RE305 v3",
+    "TP-Link RE355 v1",
+    "TP-Link RE450 v1",
+    "TP-Link RE450 v2",
+    "TP-Link RE450 v3",
+    "TP-Link TL-MR13U v1",
+    "TP-Link TL-MR3020 v1",
+    "TP-Link TL-MR3040 v1",
+    "TP-Link TL-MR3040 v2",
+    "TP-Link TL-MR3220 v1",
+    "TP-Link TL-MR3220 v2",
+    "TP-Link TL-MR3420 v1",
+    "TP-Link TL-MR3420 v2",
+    "TP-Link TL-WA701N/ND v1",
+    "TP-Link TL-WA701N/ND v2",
+    "TP-Link TL-WA730RE v1",
+    "TP-Link TL-WA750RE v1",
+    "TP-Link TL-WA801N/ND v1",
+    "TP-Link TL-WA801N/ND v2",
+    "TP-Link TL-WA801N/ND v3",
+    "TP-Link TL-WA830RE v1",
+    "TP-Link TL-WA830RE v2",
+    "TP-Link TL-WA850RE v1",
+    "TP-Link TL-WA860RE v1",
+    "TP-Link TL-WA901N/ND v1",
+    "TP-Link TL-WA901N/ND v2",
+    "TP-Link TL-WA901N/ND v3",
+    "TP-Link TL-WA901N/ND v4",
+    "TP-Link TL-WA901N/ND v5",
+    "TP-Link TL-WA7210N v2",
+    "TP-Link TL-WA7510N v1",
+    "TP-Link TL-WR703N v1",
+    "TP-Link TL-WR710N v1",
+    "TP-Link TL-WR710N v2",
+    "TP-Link TL-WR710N v2.1",
+    "TP-Link TL-WR740N/ND v1",
+    "TP-Link TL-WR740N/ND v3",
+    "TP-Link TL-WR740N/ND v4",
+    "TP-Link TL-WR740N/ND v5",
+    "TP-Link TL-WR741N/ND v1",
+    "TP-Link TL-WR741N/ND v3",
+    "TP-Link TL-WR741N/ND v4",
+    "TP-Link TL-WR741N/ND v5",
+    "TP-Link TL-WR743N/ND v1",
+    "TP-Link TL-WR743N/ND v2",
+    "TP-Link TL-WR840N v2",
+    "TP-Link TL-WR841N/ND v3",
+    "TP-Link TL-WR841N/ND v5",
+    "TP-Link TL-WR841N/ND v7",
+    "TP-Link TL-WR841N/ND v8",
+    "TP-Link TL-WR841N/ND v9",
+    "TP-Link TL-WR841N/ND v10",
+    "TP-Link TL-WR841N/ND v11",
+    "TP-Link TL-WR841N/ND v12",
+    "TP-Link TL-WR841N/ND Mod (16M) v11",
+    "TP-Link TL-WR841N/ND Mod (16M) v10",
+    "TP-Link TL-WR841N/ND Mod (16M) v8",
+    "TP-Link TL-WR841N/ND Mod (16M) v9",
+    "TP-Link TL-WR841N/ND Mod (8M) v10",
+    "TP-Link TL-WR842N/ND v1",
+    "TP-Link TL-WR842N/ND v2",
+    "TP-Link TL-WR843N/ND v1",
+    "TP-Link TL-WR940N v1",
+    "TP-Link TL-WR940N v2",
+    "TP-Link TL-WR940N v3",
+    "TP-Link TL-WR940N v4",
+    "TP-Link TL-WR940N v5",
+    "TP-Link TL-WR940N v6",
+    "TP-Link TL-WR941N/ND v2",
+    "TP-Link TL-WR941N/ND v3",
+    "TP-Link TL-WR941N/ND v4",
+    "TP-Link TL-WR941N/ND v5",
+    "TP-Link TL-WR941N/ND v6",
+    "TP-Link TL-WR1043N/ND v1",
+    "D-Link DIR-615 D1",
+    "D-Link DIR-615 D2",
+    "D-Link DIR-615 D3",
+    "D-Link DIR-615 D4",
+    "D-Link DIR-615 H1",
+    "Ubiquiti NanoStation loco M2",
+    "Ubiquiti NanoStation M2",
+    "Ubiquiti PicoStation M2",
+    "Ubiquiti Bullet M",
+    "Ubiquiti Bullet M2",
+    "Ubiquiti AirRouter",
+    "VoCore 8M",
+    "VoCore 16M"
+  ],
+  "deprecated": [
+    "TP-Link Archer C2 v3",
+    "TP-Link Archer C6 v2 (EU/RU/JP)",
+    "TP-Link Archer C6 v2",
+    "TP-Link Archer C6 v3",
+    "TP-Link Archer C20 v4",
+    "TP-Link Archer C20i",
+    "TP-Link Archer C25 v1",
+    "TP-Link Archer C50 v1",
+    "TP-Link Archer C50 v3",
+    "TP-Link Archer C50 v4",
+    "TP-Link Archer C50 v6",
+    "TP-Link Archer C60 v1",
+    "TP-Link Archer C60 v2",
+    "TP-Link CPE210 v1.0",
+    "TP-Link CPE210 v1.1",
+    "TP-Link CPE210 v1",
+    "TP-Link CPE210 v2.0",
+    "TP-Link CPE210 v2",
+    "TP-Link CPE210 v3.0",
+    "TP-Link CPE210 v3.20",
+    "TP-Link CPE210 v3",
+    "TP-Link CPE510 v1.0",
+    "TP-Link CPE510 v1.1",
+    "TP-Link CPE510 v1",
+    "TP-Link CPE510 v2",
+    "TP-Link CPE510 v3",
+    "TP-Link TL-WR902AC v1",
+    "TP-Link TL-WR902AC v3",
+    "TP-Link WBS210 v1.20",
+    "TP-Link WBS210 v2",
+    "TP-Link WBS510 v1",
+    "Ubiquiti EdgeRouter X",
+    "Ubiquiti EdgeRouter X SFP"
+  ]
+}

--- a/config.json
+++ b/config.json
@@ -529,6 +529,8 @@
        "TP-Link TL-WR902AC v3",
        "TP-Link WBS210 v1.20",
        "TP-Link WBS210 v2",
-       "TP-Link WBS510 v1"
+       "TP-Link WBS510 v1",
+       "Ubiquiti EdgeRouter X",
+       "Ubiquiti EdgeRouter X SFP"
     ]
  }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,534 @@
+{
+    "reverseGeocodingApi": "https://nominatim.openstreetmap.org/reverse",
+    "maxAge": 7,
+    "maxAgeAlert": 3,
+    "nodeZoom": 18,
+    "labelZoom": 13,
+    "clientZoom": 15,
+    "fullscreen": true,
+    "fullscreenFrame": true,
+    "nodeAttr": [
+       {
+          "name": "node.status",
+          "value": "Status"
+       },
+       {
+          "name": "node.gateway",
+          "value": "Gateway"
+       },
+       {
+          "name": "node.coordinates",
+          "value": "GeoURI"
+       },
+       {
+          "name": "node.contact",
+          "value": "owner"
+       },
+       {
+          "name": "node.hardware",
+          "value": "model"
+       },
+       {
+          "name": "node.primaryMac",
+          "value": "mac"
+       },
+       {
+          "name": "node.firmware",
+          "value": "Firmware"
+       },
+       {
+          "name": "node.uptime",
+          "value": "Uptime"
+       },
+       {
+          "name": "node.firstSeen",
+          "value": "FirstSeen"
+       },
+       {
+          "name": "node.systemLoad",
+          "value": "Load"
+       },
+       {
+          "name": "node.ram",
+          "value": "RAM"
+       },
+       {
+          "name": "node.ipAddresses",
+          "value": "IPs"
+       },
+       {
+          "name": "node.update",
+          "value": "Autoupdate"
+       },
+       {
+          "name": "node.domain",
+          "value": "Domain"
+       },
+       {
+          "name": "node.clients",
+          "value": "Clients"
+       }
+    ],
+    "supportedLocale": [
+       "en",
+       "de",
+       "cz",
+       "fr",
+       "tr",
+       "ru"
+    ],
+    "icon": {
+       "base": {
+          "fillOpacity": 0.6,
+          "opacity": 0.6,
+          "weight": 2,
+          "radius": 6,
+          "className": "stroke-first"
+       },
+       "online": {
+          "color": "#1566A9",
+          "fillColor": "#1566A9"
+       },
+       "offline": {
+          "color": "#D43E2A",
+          "fillColor": "#D43E2A",
+          "radius": 3
+       },
+       "lost": {
+          "color": "#D43E2A",
+          "fillColor": "#D43E2A",
+          "radius": 4
+       },
+       "alert": {
+          "color": "#D43E2A",
+          "fillColor": "#D43E2A",
+          "radius": 5
+       },
+       "new": {
+          "color": "#1566A9",
+          "fillColor": "#93E929"
+       }
+    },
+    "client": {
+       "wifi24": "rgba(220, 0, 103, 0.7)",
+       "wifi5": "rgba(10, 156, 146, 0.7)",
+       "other": "rgba(227, 166, 25, 0.7)"
+    },
+    "map": {
+       "labelNewColor": "#459c18",
+       "tqFrom": "#F02311",
+       "tqTo": "#04C714",
+       "highlightNode": {
+          "color": "#ad2358",
+          "weight": 8,
+          "fillOpacity": 1,
+          "opacity": 0.4,
+          "className": "stroke-first"
+       },
+       "highlightLink": {
+          "weight": 4,
+          "opacity": 1,
+          "dashArray": "5, 10"
+       }
+    },
+    "forceGraph": {
+       "nodeColor": "#fff",
+       "nodeOfflineColor": "#D43E2A",
+       "highlightColor": "rgba(255, 255, 255, 0.2)",
+       "labelColor": "#fff",
+       "tqFrom": "#770038",
+       "tqTo": "#dc0067",
+       "zoomModifier": 1
+    },
+    "locate": {
+       "outerCircle": {
+          "stroke": false,
+          "color": "#4285F4",
+          "opacity": 1,
+          "fillOpacity": 0.3,
+          "clickable": false,
+          "radius": 16
+       },
+       "innerCircle": {
+          "stroke:": true,
+          "color": "#ffffff",
+          "fillColor": "#4285F4",
+          "weight": 1.5,
+          "clickable": false,
+          "opacity": 1,
+          "fillOpacity": 1,
+          "radius": 7
+       },
+       "accuracyCircle": {
+          "stroke": true,
+          "color": "#4285F4",
+          "weight": 1,
+          "clickable": false,
+          "opacity": 0.7,
+          "fillOpacity": 0.2
+       }
+    },
+    "cacheBreaker": "22967a527",
+    "nodeInfos": [
+       {
+          "name": "Clients (24 Stunden)",
+          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?orgId=1&panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-24h",
+          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+          "title": "Clients - Knoten {NODE_ID}"
+       },
+       {
+          "name": "Traffic (24 Stunden)",
+          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-24h",
+          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+          "title": "Traffic - Knoten {NODE_ID}"
+       },
+       {
+          "name": "Clients (7 Tage)",
+          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-7d",
+          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+          "title": "Clients - Knoten {NODE_ID}"
+       },
+       {
+          "name": "Traffic (7 Tage)",
+          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
+          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+          "title": "Traffic - Knoten {NODE_ID}"
+       },
+       {
+          "name": "Uptime (7 Tage)",
+          "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=8&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
+          "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
+          "title": "Traffic - Knoten {NODE_ID}"
+       }
+    ],
+    "globalInfos": [
+       {
+          "name": "Clients",
+          "title": "Clients pro Segment",
+          "href": "https://stats.ffmuc.net",
+          "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=6&orgId=1&theme=light&width=500&height=500"
+       },
+       {
+          "name": "Traffic",
+          "title": "Traffic pro Server",
+          "href": "https://stats.ffmuc.net",
+          "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=7&orgId=1&theme=light&width=500&height=500"
+       }
+    ],
+    "dataPath": [
+       "https://map.ffmuc.net/data/"
+    ],
+    "siteName": "Freifunk München",
+    "mapLayers": [
+       {
+          "name": "FFMUC OSM Proxy",
+          "url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
+          "config": {
+             "maxZoom": 19,
+             "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+          }
+       },
+       {
+          "name": "FFMUC OSM.HOT Proxy",
+          "url": "https://tiles.ext.ffmuc.net/hot/{z}/{x}/{y}.png",
+          "config": {
+             "maxZoom": 20,
+             "attribution": "&copy; Openstreetmap France | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+          }
+       },
+       {
+          "name": "Esri.WorldImagery",
+          "url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+          "config": {
+             "maxZoom": 20,
+             "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+          }
+       }
+    ],
+    "backup_map_provider_ffmuc": [
+       {
+          "name": "HERE",
+          "url": "https://{s}.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?app_id=YOUR_KEY&app_code=YOUR_CODE&lg=deu",
+          "config": {
+             "attribution": "Map &copy; 1987-2014 <a href=\"http://developer.here.com\">HERE</a>",
+             "subdomains": "1234",
+             "maxZoom": 20
+          }
+       },
+       {
+          "name": "HERE.hybridDay",
+          "url": "https://{s}.aerial.maps.api.here.com/maptile/2.1/maptile/newest/{variant}/{z}/{x}/{y}/256/png8?app_id=YOUR_KEY&app_code=YOUR_CODE&lg=deu",
+          "config": {
+             "attribution": "Map &copy; 1987-2014 <a href=\"http://developer.here.com\">HERE</a>",
+             "subdomains": "1234",
+             "variant": "hybrid.day",
+             "maxZoom": 20
+          }
+       }
+    ],
+    "fixedCenter": [
+       [
+          48.3957886,
+          12.012732
+       ],
+       [
+          48.0428527,
+          11.2707154
+       ]
+    ],
+    "domainNames": [
+       {
+          "domain": "",
+          "name": "Unknown Domain"
+       },
+       {
+          "domain": "ffdon_mitte",
+          "name": "Donau-Ries - Mitte"
+       },
+       {
+          "domain": "ffdon_nordwest",
+          "name": "Donau-Ries - Nordwest"
+       },
+       {
+          "domain": "ffdon_sued",
+          "name": "Donau-Ries - Süd"
+       },
+       {
+          "domain": "ffmuc_muc_cty",
+          "name": "München - Stadt"
+       },
+       {
+          "domain": "ffmuc_muc_nord",
+          "name": "München - Nord"
+       },
+       {
+          "domain": "ffmuc_muc_ost",
+          "name": "München - Ost"
+       },
+       {
+          "domain": "ffmuc_muc_sued",
+          "name": "München - Süd"
+       },
+       {
+          "domain": "ffmuc_muc_west",
+          "name": "München - West"
+       },
+       {
+          "domain": "ffmuc_uml_nord",
+          "name": "Bayern - Südnord"
+       },
+       {
+          "domain": "ffmuc_uml_ost",
+          "name": "Bayern - Südost"
+       },
+       {
+          "domain": "ffmuc_uml_sued",
+          "name": "Bayern - Südsüd"
+       },
+       {
+          "domain": "ffmuc_uml_west",
+          "name": "Bayern - Südwest"
+       },
+       {
+          "domain": "ffmuc_welt",
+          "name": "Welt"
+       },
+       {
+          "domain": "ffmuc_augsburg",
+          "name": "Augsburg"
+       },
+       {
+          "domain": "ffmuc_gauting",
+          "name": "Gauting"
+       },
+       {
+          "domain": "ffmuc_freising",
+          "name": "Freising"
+       },
+       {
+         "domain": "ffmuc_ulm",
+         "name": "Ulm"
+       },
+       {
+          "domain": "ffwert_city",
+          "name": "Wertingen - City"
+       },
+       {
+          "domain": "ffwert_events",
+          "name": "Wertingen - Events"
+       },
+       {
+          "domain": "ffmuc_unifi_respondd_fallback",
+          "name": "UniFi"
+       },
+       {
+          "domain": "omada_respondd_fallback",
+          "name": "Omada"
+       }
+    ],
+    "linkList": [
+       {
+          "title": "Chat",
+          "href": "https://chat.ffmuc.net"
+       },
+       {
+          "title": "Tickets",
+          "href": "https://tickets.ffmuc.net"
+       },
+       {
+          "title": "Statistiken",
+          "href": "https://stats.ffmuc.net"
+       },
+       {
+          "title": "Kontakt",
+          "href": "https://ffmuc.net/kontakt"
+       },
+       {
+          "title": "Impressum",
+          "href": "https://ffmuc.net/impressum/"
+       }
+    ],
+     "devicePictures": "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
+     "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
+     "devicePicturesLicense": "CC-BY-NC-SA 4.0",
+    "deprecation_text": "Dieses Gerät ist leider veraltet und wird voraussichtlich nach 2025 nicht mehr durch Software-Updates unterstützt - <a href='https://ffmuc.net/freifunkmuc/2023/12/08/supportende-von-8-64-routern/'>Mehr Infos</a>",
+    "eol_text": "Dieses Gerät ist leider veraltet und wird nicht mehr durch Software-Updates unterstützt - <a href='https://bitte-router-erneuern.ffmuc.net/'>Mehr Infos</a>",
+    "deprecation_enabled": true,
+    "eol": [
+      "A5-V11",
+      "AP121",
+      "AP121U",
+      "D-Link DIR-615",
+      "D-Link DIR-615 D",
+      "D-Link DIR-825",
+      "AVM FRITZ!Box 7320",
+      "AVM FRITZ!Box 7330",
+      "AVM FRITZ!Box 7330 SL",
+      "TP-Link RE200 v1",
+      "TP-Link RE200 v2",
+      "TP-Link RE200 v3",
+      "TP-Link RE200 v4",
+      "TP-Link RE305 v1",
+      "TP-Link RE305 v2",
+      "TP-Link RE305 v3",
+      "TP-Link RE355 v1",
+      "TP-Link RE450 v1",
+      "TP-Link RE450 v2",
+      "TP-Link RE450 v3",
+      "TP-Link TL-MR13U v1",
+      "TP-Link TL-MR3020 v1",
+      "TP-Link TL-MR3040 v1",
+      "TP-Link TL-MR3040 v2",
+      "TP-Link TL-MR3220 v1",
+      "TP-Link TL-MR3220 v2",
+      "TP-Link TL-MR3420 v1",
+      "TP-Link TL-MR3420 v2",
+      "TP-Link TL-WA701N/ND v1",
+      "TP-Link TL-WA701N/ND v2",
+      "TP-Link TL-WA730RE v1",
+      "TP-Link TL-WA750RE v1",
+      "TP-Link TL-WA801N/ND v1",
+      "TP-Link TL-WA801N/ND v2",
+      "TP-Link TL-WA801N/ND v3",
+      "TP-Link TL-WA830RE v1",
+      "TP-Link TL-WA830RE v2",
+      "TP-Link TL-WA850RE v1",
+      "TP-Link TL-WA860RE v1",
+      "TP-Link TL-WA901N/ND v1",
+      "TP-Link TL-WA901N/ND v2",
+      "TP-Link TL-WA901N/ND v3",
+      "TP-Link TL-WA901N/ND v4",
+      "TP-Link TL-WA901N/ND v5",
+      "TP-Link TL-WA7210N v2",
+      "TP-Link TL-WA7510N v1",
+      "TP-Link TL-WR703N v1",
+      "TP-Link TL-WR710N v1",
+      "TP-Link TL-WR710N v2",
+      "TP-Link TL-WR710N v2.1",
+      "TP-Link TL-WR740N/ND v1",
+      "TP-Link TL-WR740N/ND v3",
+      "TP-Link TL-WR740N/ND v4",
+      "TP-Link TL-WR740N/ND v5",
+      "TP-Link TL-WR741N/ND v1",
+      "TP-Link TL-WR741N/ND v3",
+      "TP-Link TL-WR741N/ND v4",
+      "TP-Link TL-WR741N/ND v5",
+      "TP-Link TL-WR743N/ND v1",
+      "TP-Link TL-WR743N/ND v2",
+      "TP-Link TL-WR840N v2",
+      "TP-Link TL-WR841N/ND v3",
+      "TP-Link TL-WR841N/ND v5",
+      "TP-Link TL-WR841N/ND v7",
+      "TP-Link TL-WR841N/ND v8",
+      "TP-Link TL-WR841N/ND v9",
+      "TP-Link TL-WR841N/ND v10",
+      "TP-Link TL-WR841N/ND v11",
+      "TP-Link TL-WR841N/ND v12",
+      "TP-Link TL-WR841N/ND Mod (16M) v11",
+      "TP-Link TL-WR841N/ND Mod (16M) v10",
+      "TP-Link TL-WR841N/ND Mod (16M) v8",
+      "TP-Link TL-WR841N/ND Mod (16M) v9",
+      "TP-Link TL-WR841N/ND Mod (8M) v10",
+      "TP-Link TL-WR842N/ND v1",
+      "TP-Link TL-WR842N/ND v2",
+      "TP-Link TL-WR843N/ND v1",
+      "TP-Link TL-WR940N v1",
+      "TP-Link TL-WR940N v2",
+      "TP-Link TL-WR940N v3",
+      "TP-Link TL-WR940N v4",
+      "TP-Link TL-WR940N v5",
+      "TP-Link TL-WR940N v6",
+      "TP-Link TL-WR941N/ND v2",
+      "TP-Link TL-WR941N/ND v3",
+      "TP-Link TL-WR941N/ND v4",
+      "TP-Link TL-WR941N/ND v5",
+      "TP-Link TL-WR941N/ND v6",
+      "TP-Link TL-WR1043N/ND v1",
+      "D-Link DIR-615 D1",
+      "D-Link DIR-615 D2",
+      "D-Link DIR-615 D3",
+      "D-Link DIR-615 D4",
+      "D-Link DIR-615 H1",
+      "Ubiquiti NanoStation loco M2",
+      "Ubiquiti NanoStation M2",
+      "Ubiquiti PicoStation M2",
+      "Ubiquiti Bullet M",
+      "Ubiquiti Bullet M2",
+      "Ubiquiti AirRouter",
+      "VoCore 8M",
+      "VoCore 16M"
+    ],
+    "deprecated": [
+       "TP-Link Archer C2 v3",
+       "TP-Link Archer C6 v2 (EU/RU/JP)",
+       "TP-Link Archer C6 v2",
+       "TP-Link Archer C6 v3",
+       "TP-Link Archer C20 v4",
+       "TP-Link Archer C20i",
+       "TP-Link Archer C25 v1",
+       "TP-Link Archer C50 v1",
+       "TP-Link Archer C50 v3",
+       "TP-Link Archer C50 v4",
+       "TP-Link Archer C50 v6",
+       "TP-Link Archer C60 v1",
+       "TP-Link Archer C60 v2",
+       "TP-Link CPE210 v1.0",
+       "TP-Link CPE210 v1.1",
+       "TP-Link CPE210 v1",
+       "TP-Link CPE210 v2.0",
+       "TP-Link CPE210 v2",
+       "TP-Link CPE210 v3.0",
+       "TP-Link CPE210 v3.20",
+       "TP-Link CPE210 v3",
+       "TP-Link CPE510 v1.0",
+       "TP-Link CPE510 v1.1",
+       "TP-Link CPE510 v1",
+       "TP-Link CPE510 v2",
+       "TP-Link CPE510 v3",
+       "TP-Link TL-WR902AC v1",
+       "TP-Link TL-WR902AC v3",
+       "TP-Link WBS210 v1.20",
+       "TP-Link WBS210 v2",
+       "TP-Link WBS510 v1"
+    ]
+ }

--- a/config.json
+++ b/config.json
@@ -165,31 +165,31 @@
   "nodeInfos": [
     {
       "name": "Clients (24 Stunden)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?orgId=1&panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-24h",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?orgId=1&panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-24h&hideLogo=true",
       "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
       "title": "Clients - Knoten {NODE_ID}"
     },
     {
       "name": "Traffic (24 Stunden)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-24h",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-24h&hideLogo=true",
       "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
       "title": "Traffic - Knoten {NODE_ID}"
     },
     {
       "name": "Clients (7 Tage)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-7d",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-7d&hideLogo=true",
       "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
       "title": "Clients - Knoten {NODE_ID}"
     },
     {
       "name": "Traffic (7 Tage)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d&hideLogo=true",
       "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
       "title": "Traffic - Knoten {NODE_ID}"
     },
     {
       "name": "Uptime (7 Tage)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=8&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d",
+      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=8&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d&hideLogo=true",
       "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
       "title": "Traffic - Knoten {NODE_ID}"
     }

--- a/config.json
+++ b/config.json
@@ -199,13 +199,13 @@
       "name": "Clients",
       "title": "Clients pro Segment",
       "href": "https://stats.ffmuc.net",
-      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=6&orgId=1&theme=light&width=500&height=500"
+      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=6&orgId=1&theme=light&width=500&height=500&hideLogo=true"
     },
     {
       "name": "Traffic",
       "title": "Traffic pro Server",
       "href": "https://stats.ffmuc.net",
-      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=7&orgId=1&theme=light&width=500&height=500"
+      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=7&orgId=1&theme=light&width=500&height=500&hideLogo=true"
     }
   ],
   "dataPath": ["https://map.ffmuc.net/data/"],

--- a/config.json
+++ b/config.json
@@ -358,6 +358,10 @@
     {
       "domain": "omada_respondd_fallback",
       "name": "Omada"
+    },
+    {
+      "domain": "ffmuc_dlg",
+      "name": "Dillingen"
     }
   ],
   "linkList": [

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
   "fullscreen": true,
   "fullscreenFrame": true,
   "grafana": {
-    "url": "https://stats.ffmuc.net",
+    "url": "/grafana",
     "orgId": 1
   },
   "nodeCharts": [

--- a/config.json
+++ b/config.json
@@ -39,6 +39,19 @@
       ]
     }
   ],
+  "globalCharts": [
+    {
+      "name": "Clients pro Segment",
+      "datasourceUid": "000000005",
+      "datasourceType": "influxdb",
+      "query": "SELECT mean(\"clients.total\") FROM \"global_site_domain\" WHERE $timeFilter GROUP BY time($interval), \"domain\" fill(null)",
+      "alias": "$tag_domain",
+      "format": ".0f",
+      "from": "now-7d",
+      "to": "now-1m",
+      "maxDataPoints": 300
+    }
+  ],
   "nodeAttr": [
     {
       "name": "node.status",
@@ -194,52 +207,6 @@
     }
   },
   "cacheBreaker": "22967a527",
-  "nodeInfos": [
-    {
-      "name": "Clients (24 Stunden)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?orgId=1&panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-24h&hideLogo=true",
-      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-      "title": "Clients - Knoten {NODE_ID}"
-    },
-    {
-      "name": "Traffic (24 Stunden)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-24h&hideLogo=true",
-      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-      "title": "Traffic - Knoten {NODE_ID}"
-    },
-    {
-      "name": "Clients (7 Tage)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=2&var-nodeid={NODE_ID}&width=450&height=300&theme=light&from=now-7d&hideLogo=true",
-      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-      "title": "Clients - Knoten {NODE_ID}"
-    },
-    {
-      "name": "Traffic (7 Tage)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=6&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d&hideLogo=true",
-      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-      "title": "Traffic - Knoten {NODE_ID}"
-    },
-    {
-      "name": "Uptime (7 Tage)",
-      "image": "https://stats.ffmuc.net/render/d-solo/hRIn3dRWk/mesh-nodes?panelId=8&var-nodeid={NODE_ID}&width=450&height=400&theme=light&from=now-7d&hideLogo=true",
-      "href": "https://stats.ffmuc.net/d/hRIn3dRWk/mesh-nodes?orgId=1&var-nodeid={NODE_ID}",
-      "title": "Traffic - Knoten {NODE_ID}"
-    }
-  ],
-  "globalInfos": [
-    {
-      "name": "Clients",
-      "title": "Clients pro Segment",
-      "href": "https://stats.ffmuc.net",
-      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=6&orgId=1&theme=light&width=500&height=500&hideLogo=true"
-    },
-    {
-      "name": "Traffic",
-      "title": "Traffic pro Server",
-      "href": "https://stats.ffmuc.net",
-      "image": "https://stats.ffmuc.net/render/d-solo/kUoZ2DRWz/network-overview?panelId=7&orgId=1&theme=light&width=500&height=500&hideLogo=true"
-    }
-  ],
   "dataPath": ["https://map.ffmuc.net/data/"],
   "siteName": "Freifunk München",
   "mapLayers": [

--- a/config.json
+++ b/config.json
@@ -7,6 +7,38 @@
   "clientZoom": 15,
   "fullscreen": true,
   "fullscreenFrame": true,
+  "grafana": {
+    "url": "https://stats.ffmuc.net",
+    "orgId": 1
+  },
+  "nodeCharts": [
+    {
+      "name": "Clients",
+      "datasourceUid": "000000005",
+      "datasourceType": "influxdb",
+      "query": "SELECT mean(\"clients.total\") AS \"Clients\" FROM \"node\" WHERE (\"nodeid\" =~ /^$node$/) AND $timeFilter GROUP BY time($interval) fill(null)",
+      "format": ".0f",
+      "from": "now-7d",
+      "to": "now-1m",
+      "maxDataPoints": 300,
+      "series": [{ "name": "Clients", "color": "#73BF69" }]
+    },
+    {
+      "name": "Traffic",
+      "datasourceUid": "000000005",
+      "datasourceType": "influxdb",
+      "query": "SELECT non_negative_derivative(mean(\"traffic.rx.bytes\"), 1s) * 8 AS \"RX\", non_negative_derivative(mean(\"traffic.tx.bytes\"), 1s) * 8 AS \"TX\" FROM \"node\" WHERE (\"nodeid\" =~ /^$node$/) AND $timeFilter GROUP BY time($interval) fill(none)",
+      "format": ".2~s",
+      "unitSuffix": "bit/s",
+      "from": "now-7d",
+      "to": "now-1m",
+      "maxDataPoints": 300,
+      "series": [
+        { "name": "RX", "color": "#73BF69" },
+        { "name": "TX", "color": "#F2495C", "negate": true }
+      ]
+    }
+  ],
   "nodeAttr": [
     {
       "name": "node.status",

--- a/config.json
+++ b/config.json
@@ -386,9 +386,6 @@
       "href": "https://ffmuc.net/impressum/"
     }
   ],
-  "devicePictures": "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
-  "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
-  "devicePicturesLicense": "CC-BY-NC-SA 4.0",
   "deprecation_text": "Dieses Gerät ist leider veraltet und wird voraussichtlich nach 2025 nicht mehr durch Software-Updates unterstützt - <a href='https://ffmuc.net/freifunkmuc/2023/12/08/supportende-von-8-64-routern/'>Mehr Infos</a>",
   "eol_text": "Dieses Gerät ist leider veraltet und wird nicht mehr durch Software-Updates unterstützt - <a href='https://bitte-router-erneuern.ffmuc.net/'>Mehr Infos</a>",
   "deprecation_enabled": true,

--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -70,6 +70,9 @@ export interface Chart {
   datasourceUid: string;
   datasourceType: string;
   query: string;
+  // InfluxDB ALIAS BY pattern (e.g. "$tag_domain"); names the per-series frames
+  // returned by a GROUP BY tag query. Optional; single-series queries don't need it.
+  alias?: string;
   format?: string;
   unitSuffix?: string;
   from?: string;

--- a/lib/forcegraph.ts
+++ b/lib/forcegraph.ts
@@ -7,6 +7,7 @@ import * as d3Timer from "d3-timer";
 import * as d3Zoom from "d3-zoom";
 
 import math from "./utils/math.js";
+import * as helper from "./utils/helper.js";
 import draw, { MapLink, MapNode } from "./forcegraph/draw.js";
 import { Sidebar } from "./sidebar.js";
 import { ClientPointEvent } from "d3-selection";
@@ -163,7 +164,8 @@ export const ForceGraph = function (linkScale: (t: any) => any, sidebar: ReturnT
         return 0.02;
       }
       // @ts-expect-error d3 node
-      return Math.max(0.5, node.o.source_tq);
+      const metric = helper.linkMetric(node.o.source_tq, node.o.source_tp) ?? 0;
+      return Math.max(0.5, metric);
     });
 
   const zoom = d3Zoom
@@ -261,8 +263,8 @@ export const ForceGraph = function (linkScale: (t: any) => any, sidebar: ReturnT
           o: link,
           source,
           target,
-          color: linkScale(link.source_tq),
-          color_to: linkScale(link.target_tq),
+          color: linkScale(helper.linkMetric(link.source_tq, link.source_tp) ?? 0),
+          color_to: linkScale(helper.linkMetric(link.target_tq, link.target_tp) ?? 0),
           x: 0,
           y: 0,
         },

--- a/lib/forcegraph/draw.ts
+++ b/lib/forcegraph/draw.ts
@@ -125,7 +125,10 @@ const self = {
     } else if (link.o.type.indexOf("other") === 0) {
       ctx.globalAlpha = 1;
       ctx.lineWidth = 3.5;
-      if (link.o.source_tq >= 0.99 && link.o.target_tq >= 0.99) {
+      if (
+        (helper.linkMetric(link.o.source_tq, link.o.source_tp) ?? 0) >= 0.99 &&
+        (helper.linkMetric(link.o.target_tq, link.o.target_tp) ?? 0) >= 0.99
+      ) {
         link.color = config.forceGraph.otherLinkColor;
         link.color_to = config.forceGraph.otherLinkColor;
       }

--- a/lib/infobox/chart.ts
+++ b/lib/infobox/chart.ts
@@ -82,6 +82,8 @@ async function fetchChartData(
           resultFormat: "time_series",
           intervalMs,
           maxDataPoints,
+          // InfluxDB ALIAS BY, e.g. "$tag_domain" to name per-tag series from a GROUP BY
+          ...(chart.alias ? { alias: applySubst(chart.alias, subst) } : {}),
         },
       ],
       from: fromStr,

--- a/lib/infobox/link.ts
+++ b/lib/infobox/link.ts
@@ -54,7 +54,7 @@ export const Link = function (el: HTMLElement, linkData: [LinkData, ...LinkData[
         );
         helper.attributeEntry(
           children,
-          "node.tq",
+          (link.source_tp ?? 0) > 0 || (link.target_tp ?? 0) > 0 ? "node.throughput" : "node.tq",
           h(
             "span",
             {

--- a/lib/infobox/link.ts
+++ b/lib/infobox/link.ts
@@ -57,8 +57,16 @@ export const Link = function (el: HTMLElement, linkData: [LinkData, ...LinkData[
           "node.tq",
           h(
             "span",
-            { style: { color: linkScale((link.source_tq + link.target_tq) / 2) } },
-            helper.showTq(link.source_tq) + " - " + helper.showTq(link.target_tq),
+            {
+              style: {
+                color: linkScale(
+                  ((helper.linkMetric(link.source_tq, link.source_tp) ?? 0) +
+                    (helper.linkMetric(link.target_tq, link.target_tp) ?? 0)) /
+                    2,
+                ),
+              },
+            },
+            helper.showBiDiLinkMetric(link.source_tq, link.source_tp, link.target_tq, link.target_tp),
           ),
         );
 

--- a/lib/infobox/node.ts
+++ b/lib/infobox/node.ts
@@ -173,8 +173,12 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
       class: "ion-connection-bars",
       sort: function (a: Neighbour, b: Neighbour) {
         let am = helper.linkMetric(a.link.source_tq, a.link.source_tp);
+        let an = helper.linkMetric(a.link.target_tq, a.link.target_tp);
         let bm = helper.linkMetric(b.link.source_tq, b.link.source_tp);
-        return (am === undefined ? -Infinity : am) - (bm === undefined ? -Infinity : bm);
+        let bn = helper.linkMetric(b.link.target_tq, b.link.target_tp);
+        let aAvg = am === undefined && an === undefined ? -Infinity : ((am ?? 0) + (an ?? 0)) / 2;
+        let bAvg = bm === undefined && bn === undefined ? -Infinity : ((bm ?? 0) + (bn ?? 0)) / 2;
+        return aAvg - bAvg;
       },
       reverse: true,
     },

--- a/lib/infobox/node.ts
+++ b/lib/infobox/node.ts
@@ -118,7 +118,11 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
           "a",
           {
             style: {
-              color: linkScale((connecting.link.source_tq + connecting.link.target_tq) / 2),
+              color: linkScale(
+                ((helper.linkMetric(connecting.link.source_tq, connecting.link.source_tp) ?? 0) +
+                  (helper.linkMetric(connecting.link.target_tq, connecting.link.target_tp) ?? 0)) /
+                  2,
+              ),
             },
             props: {
               title: connecting.link.source.hostname + " - " + connecting.link.target.hostname,
@@ -130,7 +134,12 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
               },
             },
           },
-          helper.showTq(connecting.link.source_tq) + " - " + helper.showTq(connecting.link.target_tq),
+          helper.showBiDiLinkMetric(
+            connecting.link.source_tq,
+            connecting.link.source_tp,
+            connecting.link.target_tq,
+            connecting.link.target_tp,
+          ),
         ),
       ]),
       h("td", helper.showDistance(connecting.link)),
@@ -163,7 +172,9 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
       name: "node.tq",
       class: "ion-connection-bars",
       sort: function (a: Neighbour, b: Neighbour) {
-        return a.link.source_tq - b.link.source_tq;
+        let am = helper.linkMetric(a.link.source_tq, a.link.source_tp);
+        let bm = helper.linkMetric(b.link.source_tq, b.link.source_tp);
+        return (am === undefined ? -Infinity : am) - (bm === undefined ? -Infinity : bm);
       },
       reverse: true,
     },

--- a/lib/linklist.ts
+++ b/lib/linklist.ts
@@ -28,7 +28,13 @@ const headings: Heading[] = [
     name: "node.tq",
     class: "ion-connection-bars",
     sort: function (a, b) {
-      return (a.source_tq + a.target_tq) / 2 - (b.source_tq + b.target_tq) / 2;
+      let am = helper.linkMetric(a.source_tq, a.source_tp);
+      let bm = helper.linkMetric(b.source_tq, b.source_tp);
+      let an = helper.linkMetric(a.target_tq, a.target_tp);
+      let bn = helper.linkMetric(b.target_tq, b.target_tp);
+      let aAvg = am === undefined && an === undefined ? -Infinity : ((am ?? 0) + (an ?? 0)) / 2;
+      let bAvg = bm === undefined && bn === undefined ? -Infinity : ((bm ?? 0) + (bn ?? 0)) / 2;
+      return aAvg - bAvg;
     },
     reverse: true,
   },
@@ -77,8 +83,16 @@ export const Linklist = function (linkScale: (t: any) => any): CanRender & CanSe
       h("td", td1Content),
       h(
         "td",
-        { style: { color: linkScale((link.source_tq + link.target_tq) / 2) } },
-        helper.showTq(link.source_tq) + " - " + helper.showTq(link.target_tq),
+        {
+          style: {
+            color: linkScale(
+              ((helper.linkMetric(link.source_tq, link.source_tp) ?? 0) +
+                (helper.linkMetric(link.target_tq, link.target_tp) ?? 0)) /
+                2,
+            ),
+          },
+        },
+        helper.showBiDiLinkMetric(link.source_tq, link.source_tp, link.target_tq, link.target_tp),
       ),
       h("td", helper.showDistance(link)),
     ]);

--- a/lib/map/labellayer.js
+++ b/lib/map/labellayer.js
@@ -112,10 +112,12 @@ function addLinksToMap(dict, linkScale, graph) {
 
   return graph.map(function (link) {
     let linkColor;
-    if (link.type.indexOf("other") == 0 && link.source_tq >= 0.99 && link.target_tq >= 0.99) {
+    let sm = helper.linkMetric(link.source_tq, link.source_tp);
+    let tm = helper.linkMetric(link.target_tq, link.target_tp);
+    if (link.type.indexOf("other") == 0 && (sm ?? 0) >= 0.99 && (tm ?? 0) >= 0.99) {
       linkColor = config.map.otherLinkColor;
     } else {
-      linkColor = linkScale((link.source_tq + link.target_tq) / 2);
+      linkColor = linkScale(((sm ?? 0) + (tm ?? 0)) / 2);
     }
 
     let opts = {
@@ -136,9 +138,7 @@ function addLinksToMap(dict, linkScale, graph) {
         "<br><strong>" +
         helper.showDistance(link) +
         " / " +
-        helper.showTq(link.source_tq) +
-        " - " +
-        helper.showTq(link.target_tq) +
+        helper.showBiDiLinkMetric(link.source_tq, link.source_tp, link.target_tq, link.target_tp) +
         "<br>" +
         link.type +
         "</strong>",

--- a/lib/utils/helper.ts
+++ b/lib/utils/helper.ts
@@ -120,6 +120,63 @@ export const showTq = function showTq(tq: number) {
   return (tq * 100).toFixed(0) + "%";
 };
 
+// Format throughput in kbps as an SI-prefixed bit/s string (e.g. "24 Mbit/s").
+export const showThroughput = function showThroughput(kbps: number) {
+  if (kbps === undefined || kbps === null || isNaN(kbps)) {
+    return "";
+  }
+  let units = ["kbit/s", "Mbit/s", "Gbit/s", "Tbit/s"];
+  let value = kbps;
+  let unit = 0;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
+    unit++;
+  }
+  return (value < 10 ? value.toFixed(1) : value.toFixed(0)) + " " + units[unit];
+};
+
+// Returns a Link's link-quality metric for a given direction, normalised to a
+// 0..1 scale where higher is better. Batman IV uses tq directly (TQ=0 is
+// treated as no metric; call sites coalesce to 0 for colouring). Batman V
+// maps throughput logarithmically over [1 Mbps, 1.2 Gbps]. Returns undefined
+// when neither metric is set or non-zero.
+export const linkMetric = function linkMetric(tq: number | undefined, throughput: number | undefined) {
+  if (tq !== undefined && tq > 0) {
+    return tq;
+  }
+  if (throughput !== undefined && throughput > 0) {
+    let lo = Math.log10(1e3);
+    let hi = Math.log10(1.2e6);
+    let v = (Math.log10(throughput) - lo) / (hi - lo);
+    return Math.max(0, Math.min(1, v));
+  }
+  return undefined;
+};
+
+// Human-readable display string for a Link direction.
+export const showLinkMetric = function showLinkMetric(tq: number | undefined, throughput: number | undefined) {
+  if (tq !== undefined && tq > 0) {
+    return showTq(tq);
+  }
+  if (throughput !== undefined && throughput > 0) {
+    return showThroughput(throughput);
+  }
+  return "";
+};
+
+// Human-readable display string for both directions of a Link, omitting the
+// separator when one side has no metric (e.g. VPN gateways in Batman V).
+export const showBiDiLinkMetric = function showBiDiLinkMetric(
+  src_tq: number | undefined,
+  src_throughput: number | undefined,
+  tgt_tq: number | undefined,
+  tgt_throughput: number | undefined,
+) {
+  const src = showLinkMetric(src_tq, src_throughput);
+  const tgt = showLinkMetric(tgt_tq, tgt_throughput);
+  return [src, tgt].filter(Boolean).join(" - ");
+};
+
 export function attributeEntry(children: VNode[], label: string, value: string | VNode) {
   if (value !== undefined) {
     if (typeof value !== "object") {

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -16,8 +16,10 @@ export interface Link {
   target_addr: string;
   source_mac?: string; // Same as _addr
   target_mac?: string; // Same as _addr
-  source_tq: number;
-  target_tq: number;
+  source_tq?: number; // Batman IV link quality (0..1)
+  target_tq?: number;
+  source_tp?: number; // Batman V link quality (kbps)
+  target_tp?: number;
   latlngs?: LatLng[];
 }
 

--- a/public/locale/cz.json
+++ b/public/locale/cz.json
@@ -9,6 +9,7 @@
     "distance": "Vzdálenost",
     "connectionType": "typ připojení",
     "tq": "Kvalita přenosu",
+    "throughput": "Propustnost",
     "lastOnline": "poslední on-line  %{time} (%{date})",
     "lastOffline": "lastOffline %{time} (%{date})",
     "activated": "aktivováno (%{branch})",

--- a/public/locale/de.json
+++ b/public/locale/de.json
@@ -9,6 +9,7 @@
     "distance": "Entfernung",
     "connectionType": "Verbindungsart",
     "tq": "Übertragungsqualität",
+    "throughput": "Durchsatz",
     "lastOnline": "online, letzte Nachricht %{time} (%{date})",
     "lastOffline": "offline, letzte Nachricht %{time} (%{date})",
     "activated": "aktiviert (%{branch})",

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -9,6 +9,7 @@
     "distance": "Distance",
     "connectionType": "Connection type",
     "tq": "Transmit quality",
+    "throughput": "Throughput",
     "lastOnline": "online, last message %{time} (%{date})",
     "lastOffline": "offline, last message %{time} (%{date})",
     "activated": "activated (%{branch})",

--- a/public/locale/fr.json
+++ b/public/locale/fr.json
@@ -9,6 +9,7 @@
     "distance": "Distance",
     "connectionType": "Type de connexion",
     "tq": "Qualité de transmission",
+    "throughput": "Débit",
     "lastOnline": "en ligne, dernier message %{time} (%{date})",
     "lastOffline": "hors ligne, dernier message %{time} (%{date})",
     "activated": "activé (%{branch})",

--- a/public/locale/ru.json
+++ b/public/locale/ru.json
@@ -9,6 +9,7 @@
     "distance": "Расстояние",
     "connectionType": "Тип подключения",
     "tq": "Качество связи",
+    "throughput": "Пропускная способность",
     "lastOnline": "в сети, последнее сообщение %{time} (%{date})",
     "lastOffline": "не в сети, последнее сообщение %{time} (%{date})",
     "activated": "активировано (%{branch})",

--- a/public/locale/tr.json
+++ b/public/locale/tr.json
@@ -9,6 +9,7 @@
     "distance": "Mesafe",
     "connectionType": "Bağlantı türü",
     "tq": "İletim kalitesi",
+    "throughput": "Aktarım hızı",
     "lastOnline": "çevrimiçi, son mesaj %{time} (%{date})",
     "lastOffline": "çevrimdışı, son mesaj %{time} (%{date})",
     "activated": "aktif (%{branch})",

--- a/scss/modules/_infobox.scss
+++ b/scss/modules/_infobox.scss
@@ -22,6 +22,10 @@
 
     th,
     td {
+      &:nth-child(2) {
+        width: 42%;
+      }
+
       &:nth-child(3),
       &:nth-child(5) {
         width: 12%;


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

A GROUP BY tag InfluxDB query returns one frame per tag value, but without an ALIAS BY pattern those frames come back with the default measurement/field name, so the chart cannot label or colour them per series.

Add an optional Chart.alias config field and forward it to the /api/ds/query request as the InfluxDB query's `alias` property. The pattern (e.g. "$tag_domain") runs through the same $-substitution as the query. Single-series queries omit it and are unaffected.

## Motivation and Context

We wanted to see clients per segment

## How Has This Been Tested?

https://map.ffmuc.net/#/en/map:~:text=Clients%20pro%20Segment

## Screenshots/links:

### Before
<img width="531" height="896" alt="grafik" src="https://github.com/user-attachments/assets/b4bff193-ef38-49cf-b420-bde87a5eda65" />

### After
<img width="530" height="720" alt="grafik" src="https://github.com/user-attachments/assets/0f85100a-6a2e-48d8-8e95-a23407cb9173" />

## Checklist:

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
